### PR TITLE
Submodules are now added using https instead of ssh and some minor fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "PlayerCore"]
 	path = PlayerCore
-	url = git@github.com:OathAdPlatforms/OathVideoPartnerSDK-PlayerCore-iOS.git
+	url = https://github.com/OathAdPlatforms/OathVideoPartnerSDK-PlayerCore-iOS.git
 [submodule "PlayerControls"]
 	path = PlayerControls
-	url = git@github.com:OathAdPlatforms/OneMobileSDK-controls-ios.git
+	url = https://github.com/OathAdPlatforms/OneMobileSDK-controls-ios.git
 [submodule "VideoRenderer"]
 	path = VideoRenderer
-	url = git@github.com:OathAdPlatforms/OneMobileSDK-videorenderer-ios.git
+	url = https://github.com/OathAdPlatforms/OneMobileSDK-videorenderer-ios.git
 [submodule "fastlane/actions"]
 	path = fastlane/actions
-	url = git@github.com:OathAdPlatforms/OneMobileSDK-build-scripts-ios.git
+	url = https://github.com/OathAdPlatforms/OneMobileSDK-build-scripts-ios.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,17 @@ cache:
 git:
   depth: 1
 install:
-- bundle install
-- brew install sourcery
+  - bundle install
+  - brew install sourcery
+  - carthage update --platform iOS
 matrix:
   include:
   - os: osx
-    language: objective-c
-    osx_image: xcode10
+    osx_image: xcode10.1
     before_script:
-    - ". ./fastlane/travis\\ scripts/pre-xcode10.sh"
+    - ". ./fastlane/travis-scripts/pre-xcode10.sh"
     script:
-    - ". ./fastlane/travis\\ scripts/xcode10.sh"
+    - bundle exec fastlane test
     - bundle exec danger || true
 notifications:
   email: false
@@ -24,4 +24,4 @@ notifications:
     on_success: never
     on_failure: always
 after_success:
-- ". ./fastlane/travis scripts/update-test-app.sh"
+- ". ./fastlane/travis-scripts/update-test-app.sh"

--- a/Dangerfile
+++ b/Dangerfile
@@ -11,12 +11,6 @@ warn "#{git.commits.count} commits too many - please, squash them" if git.commit
 warn 'Please, set correct Jira link in the PR comment.' if 
 github.pr_body.include? "[JIRA Ticket](xxx)"
 
-build_type = ENV['TRAVIS_EVENT_TYPE']
-if build_type.eql? "pull_request"
-	branch_name = ENV['TRAVIS_PULL_REQUEST_BRANCH']
-	fail 'Please, attach JIRA ticket link to the branch name' unless branch_name[/OMSDK-[0-9]{3,}\/.{3,}/]
-end
-
 xcov.report(
    scheme: 'OathVideoPartnerSDK_iOS',
    Project: 'OathVideoPartnerSDK.xcodeproj'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,9 +1,9 @@
-actions_path 'actions/common/'
-actions_path 'actions/common/cocoapods/'
-actions_path 'actions/common/github/'
-actions_path 'actions/common/sourcery/'
-actions_path 'actions/common/json/'
-actions_path 'actions/common/utils/'
+actions_path 'actions/'
+actions_path 'actions/cocoapods/'
+actions_path 'actions/github/'
+actions_path 'actions/sourcery/'
+actions_path 'actions/json/'
+actions_path 'actions/utils/'
 
 before_all do |_lane, _options|
   xcversion(version: '~> 10')

--- a/sources/advertisements/VRM New Core/Controllers/StartAdProcessingControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/StartAdProcessingControllerTest.swift
@@ -1,7 +1,7 @@
 //  Copyright 2018, Oath Inc.
 //  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
 import XCTest
-@testable import OneMobileSDK
+@testable import OathVideoPartnerSDK
 @testable import PlayerCore
 
 class StartAdProcessingControllerTest: XCTestCase {
@@ -14,8 +14,8 @@ class StartAdProcessingControllerTest: XCTestCase {
     override func setUp() {
         super.setUp()
         let dispatch: (PlayerCore.Action) -> Void = recorder.hook("dispatch") { targetAction, recordedAction -> Bool in
-            if let targetAction = targetAction as? PlayerCore.NewVRMCore.AdRequest,
-                let recordedAction = recordedAction as? PlayerCore.NewVRMCore.AdRequest {
+            if let targetAction = targetAction as? PlayerCore.VRMCore.AdRequest,
+                let recordedAction = recordedAction as? PlayerCore.VRMCore.AdRequest {
                 return targetAction.type == recordedAction.type &&
                        targetAction.url == recordedAction.url
             }
@@ -55,8 +55,8 @@ class StartAdProcessingControllerTest: XCTestCase {
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.NewVRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
-            sut.dispatch(PlayerCore.NewVRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
         }
     }
     
@@ -73,7 +73,7 @@ class StartAdProcessingControllerTest: XCTestCase {
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.NewVRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
         }
     }
     
@@ -85,7 +85,7 @@ class StartAdProcessingControllerTest: XCTestCase {
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.NewVRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
         }
     }
 }


### PR DESCRIPTION
## Changes
- `Travis` now using `Xcode 10.1` image;
- Used `https` instead of `ssh` for submodules;
- Dropped `xcode10.sh` script from yml as it is not configured yet;
- Some minor fixes for successful build.

@OathAdPlatforms/mobile-sdk-developers: Please review.
