### PR TITLE
Update finish group processing

### DIFF
--- a/sources/advertisements/VRM New Core/Controllers/VRMProcessingController.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMProcessingController.swift
@@ -15,24 +15,24 @@ final class VRMProcessingController {
     
     func process(with state: PlayerCore.State) {
         process(parsingResultQueue: state.vrmParsingResult.parsedVASTs,
-                currentGroup: state.vrmCurrentGroup.currentGroup)
+                currentGroup: state.vrmCurrentGroup.currentGroup,
+                timeout: state.vrmProcessingTimeout)
     }
     
     func process(parsingResultQueue: [VRMCore.Item: VRMParsingResult.Result],
-                 currentGroup: VRMCore.Group?) {
+                 currentGroup: VRMCore.Group?,
+                 timeout: VRMProcessingTimeout) {
         parsingResultQueue
             .filter { _, result in
                 dispatchedResults.contains(result) == false
             }.forEach { item, result in
                 
-                if currentGroup == nil || currentGroup?.items.contains(item) == false {
+                if currentGroup == nil || currentGroup?.items.contains(item) == false || timeout == .hard {
                     dispatch(VRMCore.timeoutError(item: item))
                 } else if case .inline(let vast) = result.vastModel {
                     dispatch(VRMCore.selectInlineVAST(item: item, inlineVAST: vast))
                 } else if case .wrapper(let wrapper) = result.vastModel {
                     dispatch(VRMCore.unwrapItem(item: item, url: wrapper.tagURL))
-                } else {
-                    fatalError("there is no any other cases")
                 }
                 
                 dispatchedResults.insert(result)

--- a/sources/advertisements/VRM New Core/Controllers/VRMProcessingControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMProcessingControllerTest.swift
@@ -59,9 +59,26 @@ class VRMProcessingControllerTest: XCTestCase {
         recorder.record {
             let result = VRMParsingResult.Result(vastModel: inline)
             sut.process(parsingResultQueue: [vastItem: result],
-                        currentGroup: nil)
+                        currentGroup: nil,
+                        timeout: .none)
             sut.process(parsingResultQueue: [vastItem: result],
-                        currentGroup: nil)
+                        currentGroup: nil,
+                        timeout: .none)
+        }
+        
+        recorder.verify {
+            sut.dispatch(VRMCore.timeoutError(item: vastItem))
+        }
+        
+        let group = VRMCore.Group(items: [urlItem, vastItem])
+        recorder.record {
+            let result = VRMParsingResult.Result(vastModel: inline)
+            sut.process(parsingResultQueue: [vastItem: result],
+                        currentGroup: group,
+                        timeout: .hard)
+            sut.process(parsingResultQueue: [vastItem: result],
+                        currentGroup: group,
+                        timeout: .hard)
         }
         
         recorder.verify {
@@ -75,7 +92,8 @@ class VRMProcessingControllerTest: XCTestCase {
         let group = VRMCore.Group(items: [urlItem])
         recorder.record {
             sut.process(parsingResultQueue: [vastItem: .init(vastModel: inline)],
-                        currentGroup: group)
+                        currentGroup: group,
+                        timeout: .none)
         }
         
         recorder.verify {
@@ -90,7 +108,8 @@ class VRMProcessingControllerTest: XCTestCase {
         let group = VRMCore.Group(items: [urlItem])
         recorder.record {
             sut.process(parsingResultQueue: [urlItem: .init(vastModel: inline)],
-                        currentGroup: group)
+                        currentGroup: group,
+                        timeout: .soft)
         }
         
         recorder.verify {
@@ -105,7 +124,8 @@ class VRMProcessingControllerTest: XCTestCase {
         let group = VRMCore.Group(items: [urlItem])
         recorder.record {
             sut.process(parsingResultQueue: [urlItem: .init(vastModel: wrapper)],
-                        currentGroup: group)
+                        currentGroup: group,
+                        timeout: .none)
         }
         
         recorder.verify {


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Fixed logic of finishing group
Have to finish group in case of:
* All items in group already failed
* Tried all processed items after the hard timeout and all of them are failed

Added timeout handling to VRMProcessingController

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
