### PR TITLE
Updated start group controller

### DIFF
--- a/sources/advertisements/VRM New Core/Controllers/StartVRMGroupProcessingController.swift
+++ b/sources/advertisements/VRM New Core/Controllers/StartVRMGroupProcessingController.swift
@@ -7,6 +7,7 @@ import PlayerCore
 final class StartVRMGroupProcessingController {
     
     let dispatch: (PlayerCore.Action) -> ()
+    private var trackedRequests = Set<UUID>()
     
     init(dispatch: @escaping (PlayerCore.Action) -> ()) {
         self.dispatch = dispatch
@@ -15,16 +16,26 @@ final class StartVRMGroupProcessingController {
     func process(with state: PlayerCore.State) {
         process(with: state.vrmCurrentGroup.currentGroup,
                 groupsQueue: state.vrmGroupsQueue.groupsQueue,
-            isMaxAdSearchReached: state.vrmMaxAdSearchTimeout.isReached)
+                isMaxAdSearchReached: state.vrmMaxAdSearchTimeout.isReached,
+            vrmRequest: state.vrmRequestStatus.request,
+            hasReceivedVRMResponse: state.vrmResponse != nil)
     }
     
     func process(with currentGroup: VRMCore.Group?,
                  groupsQueue: [VRMCore.Group],
-        isMaxAdSearchReached: Bool) {
+                 isMaxAdSearchReached: Bool,
+                 vrmRequest: VRMRequestStatus.Request,
+                 hasReceivedVRMResponse: Bool) {
         guard currentGroup == nil,
-            let nextGroup = groupsQueue.first,
+            hasReceivedVRMResponse,
             isMaxAdSearchReached == false else { return }
         
-        dispatch(VRMCore.startGroupProcessing(group: nextGroup))
+        if let nextGroup = groupsQueue.first {
+            dispatch(VRMCore.startGroupProcessing(group: nextGroup))
+        } else if case let .request(_, id) = vrmRequest,
+            trackedRequests.contains(id) == false {
+            trackedRequests.insert(id)
+            dispatch(VRMCore.noGroupsToProcess(id: id))
+        }
     }
 }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Start group controller should dispatch action `NoMoreGroupsForProcessing` in case of empty vrm response or if we've already processed all groups and final result is still empty. 

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
