### PR TITLE
Added midroll support

### DIFF
--- a/sources/advertisements/VRM New Core/Controllers/FinalResultDispatchController.swift
+++ b/sources/advertisements/VRM New Core/Controllers/FinalResultDispatchController.swift
@@ -17,17 +17,20 @@ final class FinalResultDispatchController {
     }
     
     func process(with state: PlayerCore.State) {
-        process(with: state.vrmFinalResult.result)
+        process(with: state.vrmFinalResult.result,
+                requestID: state.vrmRequestStatus.request?.id)
     }
     
-    func process(with finalResult: VRMCore.Result?) {
+    func process(with finalResult: VRMCore.Result?,
+                 requestID: UUID?) {
         guard let finalResult = finalResult,
+            let requestID = requestID,
             firedResults.contains(finalResult) == false else {
                 return
         }
         firedResults.insert(finalResult)
         dispatch(PlayerCore.playAd(model: finalResult.inlineVAST,
-                                   id: UUID(),
+                                   id: requestID,
                                    isOpenMeasurementEnabled: isOpenMeasurementEnabled))
     }
 }

--- a/sources/advertisements/VRM New Core/Controllers/FinalResultDispatchControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/FinalResultDispatchControllerTest.swift
@@ -40,9 +40,11 @@ class FinalResultDispatchControllerTest: XCTestCase {
         let result = VRMCore.Result(item: item, inlineVAST: inlineVAST)
         
         recorder.record {
-            sut.process(with: nil)
-            sut.process(with: result)
-            sut.process(with: result)
+            let uuid = UUID()
+            sut.process(with: nil, requestID: nil)
+            sut.process(with: nil, requestID: uuid)
+            sut.process(with: result, requestID: uuid)
+            sut.process(with: result, requestID: uuid)
         }
         
         recorder.verify {

--- a/sources/advertisements/VRM New Core/Controllers/StartAdProcessingController.swift
+++ b/sources/advertisements/VRM New Core/Controllers/StartAdProcessingController.swift
@@ -6,23 +6,36 @@ import PlayerCore
 final class StartAdProcessingController {
     
     let dispatch: (PlayerCore.Action) -> Void
+    let prefetchOffset: Int
     
     private var sessionID = UUID()
     private var isPrerollRequested = false
+    private var lastMidroll: PlayerCore.Ad.Midroll?
     
-    init(dispatch: @escaping (PlayerCore.Action) -> Void) {
+    init(prefetchOffset: Int,
+         dispatch: @escaping (PlayerCore.Action) -> Void) {
+        self.prefetchOffset = prefetchOffset
         self.dispatch = dispatch
     }
     
     func process(props: Player.Properties) {
-        process(with: props.playbackItem?.model.ad.preroll.first?.url,
-                isPlaybackInitiated: props.isPlaybackInitiated,
-                sessionID: props.session.playback.id)
+        processPreroll(with: props.playbackItem?.model.ad.preroll.first?.url,
+                       isPlaybackInitiated: props.isPlaybackInitiated,
+                       sessionID: props.session.playback.id)
+        
+        guard let item = props.playbackItem,
+            let currentTime = item.content.time.static?.current else { return }
+        
+        processMidroll(midrolls: item.midrolls,
+                       currentTime: currentTime,
+                       hasActiveAds: item.hasActiveAds,
+                       isPlayMidrollAllowed: item.content.isPaused == false && item.content.isSeeking == false)
     }
     
-    func process(with url: URL?,
-                 isPlaybackInitiated: Bool,
-                 sessionID: UUID) {
+    func processPreroll(with url: URL?,
+                        isPlaybackInitiated: Bool,
+                        sessionID: UUID,
+                        requestID: UUID = UUID()) {
         guard let url = url,
             isPlaybackInitiated else { return }
         
@@ -33,7 +46,38 @@ final class StartAdProcessingController {
         
         if isPrerollRequested == false {
             isPrerollRequested = true
-            dispatch(VRMCore.adRequest(url: url, id: UUID(), type: .preroll))
+            dispatch(VRMCore.adRequest(url: url, id: requestID, type: .preroll))
+        }
+    }
+    
+    func processMidroll(midrolls: [PlayerCore.Ad.Midroll],
+                        currentTime: Double,
+                        hasActiveAds: Bool,
+                        isPlayMidrollAllowed: Bool) {
+        guard hasActiveAds == false,
+            isPlayMidrollAllowed else { return }
+        
+        let roundedTime: Int = perform {
+            guard currentTime > Double(Int.min) && currentTime < Double(Int.max) else { return 0 }
+            return Int(currentTime)
+        }
+        
+        let midrollsBeforeCurrentTime = midrolls.filter {
+            $0.cuePoint < roundedTime && $0.cuePoint > lastMidroll?.cuePoint ?? 0
+        }
+        
+        let midrollsAfterCurrentTime = midrolls.filter {
+            $0.cuePoint >= roundedTime
+        }
+        
+        let midrollToPlay = midrollsBeforeCurrentTime.last ??
+            midrollsAfterCurrentTime.first{ $0.cuePoint == roundedTime }
+        
+        if let midroll = midrollToPlay,
+            lastMidroll?.id != midroll.id {
+            lastMidroll = midroll
+            dispatch(VRMCore.adRequest(url: midroll.url, id: midroll.id, type: .midroll))
         }
     }
 }
+

--- a/sources/advertisements/VRM New Core/Controllers/StartAdProcessingControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/StartAdProcessingControllerTest.swift
@@ -8,17 +8,21 @@ class StartAdProcessingControllerTest: XCTestCase {
     
     let url = URL(string: "test")!
     let recorder = Recorder()
+    let requestID = UUID()
+    let midrolls: [PlayerCore.Ad.Midroll] = [.init(cuePoint: 10, url: URL(string: "http://some_url_1")!, id: UUID()),
+                                             .init(cuePoint: 15, url: URL(string: "http://some_url_2")!, id: UUID()),
+                                             .init(cuePoint: 20, url: URL(string: "http://some_url_3")!, id: UUID())]
     
     var sut: StartAdProcessingController!
     
     override func setUp() {
         super.setUp()
         let actionComparator = ActionComparator<VRMCore.AdRequest> {
-            $0.type == $1.type && $0.url == $1.url
+            $0.type == $1.type && $0.url == $1.url && $0.id == $1.id
         }
         let dispatch = recorder.hook("dispatch", cmp: actionComparator.compare)
         
-        sut = StartAdProcessingController(dispatch: dispatch)
+        sut = StartAdProcessingController(prefetchOffset: 5, dispatch: dispatch)
     }
     
     override func tearDown() {
@@ -29,60 +33,152 @@ class StartAdProcessingControllerTest: XCTestCase {
     
     func testNoDispatch() {
         recorder.record {
-            sut.process(with: nil,
-                        isPlaybackInitiated: true,
-                        sessionID: UUID())
+            sut.processPreroll(with: nil,
+                               isPlaybackInitiated: true,
+                               sessionID: UUID())
             
-            sut.process(with: url,
-                        isPlaybackInitiated: false,
-                        sessionID: UUID())
+            sut.processPreroll(with: url,
+                               isPlaybackInitiated: false,
+                               sessionID: UUID())
         }
         recorder.verify {}
     }
     
     func testDiffSessions() {
         recorder.record {
-            sut.process(with: url,
-                        isPlaybackInitiated: true,
-                        sessionID: UUID())
+            sut.processPreroll(with: url,
+                               isPlaybackInitiated: true,
+                               sessionID: UUID(),
+                               requestID: requestID)
             
-            sut.process(with: url,
-                        isPlaybackInitiated: true,
-                        sessionID: UUID())
+            sut.processPreroll(with: url,
+                               isPlaybackInitiated: true,
+                               sessionID: UUID(),
+                               requestID: requestID)
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
-            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: requestID, type: .preroll))
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: requestID, type: .preroll))
         }
     }
     
     func testSecondDisptach() {
         recorder.record {
             let sessionID = UUID()
-            sut.process(with: url,
-                        isPlaybackInitiated: true,
-                        sessionID: sessionID)
+            sut.processPreroll(with: url,
+                               isPlaybackInitiated: true,
+                               sessionID: sessionID,
+                               requestID: requestID)
             
-            sut.process(with: url,
-                        isPlaybackInitiated: true,
-                        sessionID: sessionID)
+            sut.processPreroll(with: url,
+                               isPlaybackInitiated: true,
+                               sessionID: sessionID,
+                               requestID: requestID)
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: requestID, type: .preroll))
         }
     }
     
     func testCorrectDispatch() {
         recorder.record {
-            sut.process(with: url,
-                        isPlaybackInitiated: true,
-                        sessionID: UUID())
+            sut.processPreroll(with: url,
+                               isPlaybackInitiated: true,
+                               sessionID: UUID(),
+                               requestID: requestID)
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: url, id: requestID, type: .preroll))
+        }
+    }
+    
+    func testTimeToPlayMidroll() {
+        let midroll = midrolls[0]
+        recorder.record {
+            sut.processMidroll(midrolls: midrolls,
+                               currentTime: 10.0,
+                               hasActiveAds: false,
+                               isPlayMidrollAllowed: true)
+            
+            sut.processMidroll(midrolls: midrolls,
+                               currentTime: 14.0,
+                               hasActiveAds: false,
+                               isPlayMidrollAllowed: true)
+        }
+        
+        recorder.verify {
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: midroll.url,
+                                                      id: midroll.id,
+                                                      type: .midroll))
+        }
+    }
+    
+    func testSeekOverFirstMidroll() {
+        let midroll = midrolls[0]
+        recorder.record {
+            sut.processMidroll(midrolls: midrolls,
+                               currentTime: 12.0,
+                               hasActiveAds: false,
+                               isPlayMidrollAllowed: true)
+        }
+        
+        recorder.verify {
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: midroll.url,
+                                                      id: midroll.id,
+                                                      type: .midroll))
+        }
+    }
+    
+    func testSeekOverFirstAndSecondMidrolls() {
+        let midroll = midrolls[1]
+        recorder.record {
+            sut.processMidroll(midrolls: midrolls,
+                               currentTime: 16.0,
+                               hasActiveAds: false,
+                               isPlayMidrollAllowed: true)
+            
+            var dropped = midrolls
+            dropped.remove(at: 1)
+            sut.processMidroll(midrolls: dropped,
+                               currentTime: 17.0,
+                               hasActiveAds: false,
+                               isPlayMidrollAllowed: true)
+        }
+        
+        recorder.verify {
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: midroll.url,
+                                                      id: midroll.id,
+                                                      type: .midroll))
+        }
+    }
+    
+    func testSeekOverAllMidrollsAndSeekBack() {
+        let firstMidroll = midrolls[1]
+        let lastMidroll = midrolls[2]
+        recorder.record {
+            sut.processMidroll(midrolls: midrolls,
+                               currentTime: 21.0,
+                               hasActiveAds: false,
+                               isPlayMidrollAllowed: true)
+            
+            var dropped = midrolls
+            dropped.remove(at: 2)
+            sut.processMidroll(midrolls: dropped,
+                               currentTime: 15.0,
+                               hasActiveAds: false,
+                               isPlayMidrollAllowed: true)
+        }
+        
+        recorder.verify {
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: lastMidroll.url,
+                                                      id: lastMidroll.id,
+                                                      type: .midroll))
+            sut.dispatch(PlayerCore.VRMCore.AdRequest(url: firstMidroll.url,
+                                                      id: firstMidroll.id,
+                                                      type: .midroll))
         }
     }
 }

--- a/sources/advertisements/VRM New Core/Controllers/StartVRMGroupProcessingController.swift
+++ b/sources/advertisements/VRM New Core/Controllers/StartVRMGroupProcessingController.swift
@@ -24,7 +24,7 @@ final class StartVRMGroupProcessingController {
     func process(with currentGroup: VRMCore.Group?,
                  groupsQueue: [VRMCore.Group],
                  isMaxAdSearchReached: Bool,
-                 vrmRequest: VRMRequestStatus.Request,
+                 vrmRequest: VRMRequestStatus.Request?,
                  hasReceivedVRMResponse: Bool) {
         guard currentGroup == nil,
             hasReceivedVRMResponse,
@@ -32,10 +32,10 @@ final class StartVRMGroupProcessingController {
         
         if let nextGroup = groupsQueue.first {
             dispatch(VRMCore.startGroupProcessing(group: nextGroup))
-        } else if case let .request(_, id) = vrmRequest,
-            trackedRequests.contains(id) == false {
-            trackedRequests.insert(id)
-            dispatch(VRMCore.noGroupsToProcess(id: id))
+        } else if let request = vrmRequest,
+            trackedRequests.contains(request.id) == false {
+            trackedRequests.insert(request.id)
+            dispatch(VRMCore.noGroupsToProcess(id: request.id))
         }
     }
 }

--- a/sources/advertisements/VRM New Core/Controllers/StartVRMGroupProcessingControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/StartVRMGroupProcessingControllerTest.swift
@@ -22,7 +22,7 @@ class StartVRMGroupProcessingControllerTest: XCTestCase {
         }
         let dispatch = recorder.hook("dispatch", cmp: actionComparator.compare)
         sut = StartVRMGroupProcessingController(dispatch: dispatch)
-        request = .request(url: URL(string:"http://test.com")!, id: id)
+        request = VRMRequestStatus.Request(url: URL(string:"http://test.com")!, id: id)
     }
     
     override func tearDown() {

--- a/sources/advertisements/VRM New Core/Controllers/VRMRequestController.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMRequestController.swift
@@ -53,17 +53,17 @@ final class VRMRequestController {
         process(with: state.vrmRequestStatus.request)
     }
     
-    func process(with requestStatus: PlayerCore.VRMRequestStatus.Request) {
+    func process(with request: PlayerCore.VRMRequestStatus.Request?) {
         
-        if case let .request(url, id) = requestStatus,
-            firedRequests.contains(id) == false {
+        if let request = request,
+            firedRequests.contains(request.id) == false {
             
-            firedRequests.insert(id)
+            firedRequests.insert(request.id)
             weak var weakSelf = self
-            fetchVRMResponse(url).onComplete { response in
+            fetchVRMResponse(request.url).onComplete { response in
                 guard let response = response,
                     let `self` = weakSelf else {
-                        weakSelf?.dispatch(VRMCore.adResponseFetchFailed(requestID: id))
+                        weakSelf?.dispatch(VRMCore.adResponseFetchFailed(requestID: request.id))
                         return
                 }
                 weakSelf?.dispatch(VRMCore.adResponse(transactionId: response.transactionId,

--- a/sources/advertisements/VRM New Core/Controllers/VRMRequestControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMRequestControllerTest.swift
@@ -79,8 +79,8 @@ class VRMRequestControllerTest: XCTestCase {
         
         recorder.record {
             let requestId = UUID()
-            sut.process(with: .request(url: vrmURL, id: requestId))
-            sut.process(with: .request(url: vrmURL, id: requestId))
+            sut.process(with: .init(url: vrmURL, id: requestId))
+            sut.process(with: .init(url: vrmURL, id: requestId))
         }
         
         recorder.verify {
@@ -90,8 +90,8 @@ class VRMRequestControllerTest: XCTestCase {
         }
         
         recorder.record {
-            sut.process(with: .request(url: vrmURL, id: UUID()))
-            sut.process(with: .request(url: vrmURL, id: UUID()))
+            sut.process(with: .init(url: vrmURL, id: UUID()))
+            sut.process(with: .init(url: vrmURL, id: UUID()))
         }
         
         recorder.verify {
@@ -120,7 +120,7 @@ class VRMRequestControllerTest: XCTestCase {
         
         let requestID = UUID()
         recorder.record {
-            sut.process(with: .request(url: vrmURL, id: requestID))
+            sut.process(with: .init(url: vrmURL, id: requestID))
         }
         
         recorder.verify {


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Updated vrm request. Replace enum with struct

Added midrolls:
Midroll plays if cue point was reached.
In case of seeking, we will play the nearest midroll before the current time.

Main logic of midroll selection 

```swift
let midrollsBeforeCurrentTime = midrolls.filter {
            $0.cuePoint < currentTime && 
            $0.cuePoint > lastMidroll?.cuePoint ?? 0
        }

         let midrollsAfterCurrentTime = midrolls.filter {
            $0.cuePoint >= currentTime
        }

         let midrollToPlay = midrollsBeforeCurrentTime.last ??
            midrollsAfterCurrentTime.first { $0.cuePoint == currentTime }
```

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.