### PR TITLE
Updated for the latest changes in Player Core

### DIFF
--- a/sources/advertisements/AdURLProviderProcess.swift
+++ b/sources/advertisements/AdURLProviderProcess.swift
@@ -86,7 +86,7 @@ final class AdURLProviderProcess {
     
     private func descriptionFor(result: PlayerCore.Ad.VASTModel) -> JSON {
         return [
-            "media file": result.videos.first?.url.absoluteString ?? NSNull(),
+            "media file": result.mp4MediaFiles.first?.url.absoluteString ?? result.vpaidMediaFiles.first?.url.absoluteString ?? NSNull(),
             "click": result.clickthrough?.absoluteString ?? NSNull(),
             "id": result.id ?? NSNull()
         ]

--- a/sources/advertisements/AdURLProviderProcess.swift
+++ b/sources/advertisements/AdURLProviderProcess.swift
@@ -86,7 +86,7 @@ final class AdURLProviderProcess {
     
     private func descriptionFor(result: PlayerCore.Ad.VASTModel) -> JSON {
         return [
-            "media file": result.mediaFiles.first?.url.absoluteString ?? NSNull(),
+            "media file": result.videos.first?.url.absoluteString ?? NSNull(),
             "click": result.clickthrough?.absoluteString ?? NSNull(),
             "id": result.id ?? NSNull()
         ]

--- a/sources/advertisements/AdVRMEngine.swift
+++ b/sources/advertisements/AdVRMEngine.swift
@@ -95,8 +95,8 @@ func select(model: PlayerCore.Ad.VASTModel,
             info: VRMMetaInfo,
             requestDate: Date,
             isVPAIDAllowed: Bool) -> PlayerCore.Ad.VASTModel? {
-    let mediaFiles = model.mediaFiles.filter {
-        guard case .vpaid = $0.type else { return true }
+    let mediaFiles = model.videos.filter {
+        guard case .vpaid = $0 else { return true }
         return isVPAIDAllowed
     }
     guard !mediaFiles.isEmpty else {

--- a/sources/advertisements/AdVRMEngine.swift
+++ b/sources/advertisements/AdVRMEngine.swift
@@ -95,11 +95,8 @@ func select(model: PlayerCore.Ad.VASTModel,
             info: VRMMetaInfo,
             requestDate: Date,
             isVPAIDAllowed: Bool) -> PlayerCore.Ad.VASTModel? {
-    let mediaFiles = model.videos.filter {
-        guard case .vpaid = $0 else { return true }
-        return isVPAIDAllowed
-    }
-    guard !mediaFiles.isEmpty else {
+    let isModelContainsAds = (isVPAIDAllowed && !model.vpaidMediaFiles.isEmpty) || !model.mp4MediaFiles.isEmpty
+    guard isModelContainsAds else {
         dispatcher(PlayerCore.adVRMItemOtherError(info: info,
                                                   requestDate: requestDate,
                                                   responseDate: Date()))

--- a/sources/advertisements/MidrollDetector.swift
+++ b/sources/advertisements/MidrollDetector.swift
@@ -146,8 +146,7 @@ extension MidrollDetector.Action: Equatable {
         case (.prefetch(let lhsMidroll), .prefetch(let rhsMidroll)):
             return lhsMidroll == rhsMidroll
         case (.play(let lhsPrefetchedModel, let lhsPrefetchedMidroll), .play(let rhsPrefetchedModel, let rhsPrefetchedMidroll)):
-            return lhsPrefetchedModel?.videos.first == rhsPrefetchedModel?.videos.first
-                && lhsPrefetchedMidroll == rhsPrefetchedMidroll
+            return lhsPrefetchedModel == rhsPrefetchedModel && lhsPrefetchedMidroll == rhsPrefetchedMidroll
         default: return false
         }
     }

--- a/sources/advertisements/MidrollDetector.swift
+++ b/sources/advertisements/MidrollDetector.swift
@@ -146,7 +146,7 @@ extension MidrollDetector.Action: Equatable {
         case (.prefetch(let lhsMidroll), .prefetch(let rhsMidroll)):
             return lhsMidroll == rhsMidroll
         case (.play(let lhsPrefetchedModel, let lhsPrefetchedMidroll), .play(let rhsPrefetchedModel, let rhsPrefetchedMidroll)):
-            return lhsPrefetchedModel?.mediaFiles.first?.url == rhsPrefetchedModel?.mediaFiles.first?.url
+            return lhsPrefetchedModel?.videos.first == rhsPrefetchedModel?.videos.first
                 && lhsPrefetchedMidroll == rhsPrefetchedMidroll
         default: return false
         }

--- a/sources/advertisements/MidrollDetectorTests.swift
+++ b/sources/advertisements/MidrollDetectorTests.swift
@@ -50,13 +50,12 @@ class MidrollDetectorTests: QuickSpec {
                         return Future {
                             model = PlayerCore.Ad.VASTModel(
                                 adVerifications: [],
-                                videos: [.mp4(
-                                    PlayerCore.Ad.VASTModel.MediaFile(
-                                        url: url,
-                                        width: 300,
-                                        height: 400,
-                                        scalable: false,
-                                        maintainAspectRatio: true))],
+                                mp4MediaFiles: [.init(url: URL(string:"http://test.mp4")!,
+                                                      width: 1,
+                                                      height: 1,
+                                                      scalable: true,
+                                                      maintainAspectRatio: true)],
+                                vpaidMediaFiles: [],
                                 clickthrough: nil,
                                 adParameters: nil,
                                 pixels: .init(),
@@ -171,7 +170,7 @@ class MidrollDetectorTests: QuickSpec {
                             type: .midroll))
                         _ = midrollDetector.requestAd(midroll.url)
                         expect(midrollDetector.state.lastPrefetchedMidroll) == midroll
-                        expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
+                        expect(midrollDetector.state.prefetchedModel) == model
                     }
                 }
                 
@@ -196,7 +195,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             
                             guard let model = model else { return XCTFail("Got nil ad model") }
-                            expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
+                            expect(midrollDetector.state.prefetchedModel) == model
                             
                             midrollDetector.process(input: input)
                         }
@@ -221,7 +220,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             
                             guard let model = model else { return XCTFail("Got nil ad model") }
-                            expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
+                            expect(midrollDetector.state.prefetchedModel) == model
                             
                             midrollDetector.process(input: input)
                         }
@@ -246,7 +245,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             
                             guard let model = model else { return XCTFail("Got nil ad model") }
-                            expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
+                            expect(midrollDetector.state.prefetchedModel) == model
                             
                             midrollDetector.process(input: input)
                         }
@@ -272,7 +271,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             expect(midrollDetector.state.lastPrefetchedMidroll) == input.midrolls[1]
                             if let model = model {
-                                expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
+                                expect(midrollDetector.state.prefetchedModel) == model
                             } else { return XCTFail("Got nil ad model") }
                             // should play 2
                             midrollDetector.process(input: input)
@@ -281,7 +280,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             expect(midrollDetector.state.lastPrefetchedMidroll) == input.midrolls[2]
                             if let model = model {
-                                expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
+                                expect(midrollDetector.state.prefetchedModel) == model
                             } else { return XCTFail("Got nil ad model") }
                             // should play 3
                             input.currentTime = 20
@@ -323,7 +322,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             expect(midrollDetector.state.lastPrefetchedMidroll) == input.midrolls[1]
                             if let model = model {
-                                expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
+                                expect(midrollDetector.state.prefetchedModel) == model
                             } else { return XCTFail("Got nil ad model") }
                             // should play 2
                             midrollDetector.process(input: input)
@@ -332,7 +331,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             expect(midrollDetector.state.lastPrefetchedMidroll) == input.midrolls[2]
                             if let model = model {
-                                expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
+                                expect(midrollDetector.state.prefetchedModel) == model
                             } else { return XCTFail("Got nil ad model") }
                             // should play 1
                             input.currentTime = 10

--- a/sources/advertisements/MidrollDetectorTests.swift
+++ b/sources/advertisements/MidrollDetectorTests.swift
@@ -50,13 +50,13 @@ class MidrollDetectorTests: QuickSpec {
                         return Future {
                             model = PlayerCore.Ad.VASTModel(
                                 adVerifications: [],
-                                mediaFiles: [PlayerCore.Ad.VASTModel.MediaFile(
-                                    url: url,
-                                    type: .mp4,
-                                    width: 300,
-                                    height: 400,
-                                    scalable: false,
-                                    maintainAspectRatio: true)],
+                                videos: [.mp4(
+                                    PlayerCore.Ad.VASTModel.MediaFile(
+                                        url: url,
+                                        width: 300,
+                                        height: 400,
+                                        scalable: false,
+                                        maintainAspectRatio: true))],
                                 clickthrough: nil,
                                 adParameters: nil,
                                 pixels: .init(),
@@ -171,7 +171,7 @@ class MidrollDetectorTests: QuickSpec {
                             type: .midroll))
                         _ = midrollDetector.requestAd(midroll.url)
                         expect(midrollDetector.state.lastPrefetchedMidroll) == midroll
-                        expect(midrollDetector.state.prefetchedModel?.mediaFiles.first?.url) == model.mediaFiles.first?.url
+                        expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
                     }
                 }
                 
@@ -196,7 +196,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             
                             guard let model = model else { return XCTFail("Got nil ad model") }
-                            expect(midrollDetector.state.prefetchedModel?.mediaFiles.first?.url) == model.mediaFiles.first?.url
+                            expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
                             
                             midrollDetector.process(input: input)
                         }
@@ -221,7 +221,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             
                             guard let model = model else { return XCTFail("Got nil ad model") }
-                            expect(midrollDetector.state.prefetchedModel?.mediaFiles.first?.url) == model.mediaFiles.first?.url
+                            expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
                             
                             midrollDetector.process(input: input)
                         }
@@ -246,7 +246,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             
                             guard let model = model else { return XCTFail("Got nil ad model") }
-                            expect(midrollDetector.state.prefetchedModel?.mediaFiles.first?.url) == model.mediaFiles.first?.url
+                            expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
                             
                             midrollDetector.process(input: input)
                         }
@@ -272,7 +272,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             expect(midrollDetector.state.lastPrefetchedMidroll) == input.midrolls[1]
                             if let model = model {
-                                expect(midrollDetector.state.prefetchedModel?.mediaFiles.first?.url) == model.mediaFiles.first?.url
+                                expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
                             } else { return XCTFail("Got nil ad model") }
                             // should play 2
                             midrollDetector.process(input: input)
@@ -281,7 +281,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             expect(midrollDetector.state.lastPrefetchedMidroll) == input.midrolls[2]
                             if let model = model {
-                                expect(midrollDetector.state.prefetchedModel?.mediaFiles.first?.url) == model.mediaFiles.first?.url
+                                expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
                             } else { return XCTFail("Got nil ad model") }
                             // should play 3
                             input.currentTime = 20
@@ -323,7 +323,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             expect(midrollDetector.state.lastPrefetchedMidroll) == input.midrolls[1]
                             if let model = model {
-                                expect(midrollDetector.state.prefetchedModel?.mediaFiles.first?.url) == model.mediaFiles.first?.url
+                                expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
                             } else { return XCTFail("Got nil ad model") }
                             // should play 2
                             midrollDetector.process(input: input)
@@ -332,7 +332,7 @@ class MidrollDetectorTests: QuickSpec {
                             midrollDetector.process(input: input)
                             expect(midrollDetector.state.lastPrefetchedMidroll) == input.midrolls[2]
                             if let model = model {
-                                expect(midrollDetector.state.prefetchedModel?.mediaFiles.first?.url) == model.mediaFiles.first?.url
+                                expect(midrollDetector.state.prefetchedModel?.videos.first?.url) == model.videos.first?.url
                             } else { return XCTFail("Got nil ad model") }
                             // should play 1
                             input.currentTime = 10

--- a/sources/advertisements/VASTModel.swift
+++ b/sources/advertisements/VASTModel.swift
@@ -21,7 +21,8 @@ extension PlayerCore.Ad.VASTModel {
     func merge(with pixels: AdPixels, and verifications: [PlayerCore.Ad.VASTModel.AdVerification]) -> PlayerCore.Ad.VASTModel {
         return PlayerCore.Ad.VASTModel(
             adVerifications: self.adVerifications + verifications,
-            videos: videos,
+            mp4MediaFiles: mp4MediaFiles,
+            vpaidMediaFiles: vpaidMediaFiles,
             clickthrough: clickthrough,
             adParameters: adParameters,
             pixels: self.pixels.merge(with: pixels),

--- a/sources/advertisements/VASTModel.swift
+++ b/sources/advertisements/VASTModel.swift
@@ -21,7 +21,7 @@ extension PlayerCore.Ad.VASTModel {
     func merge(with pixels: AdPixels, and verifications: [PlayerCore.Ad.VASTModel.AdVerification]) -> PlayerCore.Ad.VASTModel {
         return PlayerCore.Ad.VASTModel(
             adVerifications: self.adVerifications + verifications,
-            mediaFiles: mediaFiles,
+            videos: videos,
             clickthrough: clickthrough,
             adParameters: adParameters,
             pixels: self.pixels.merge(with: pixels),

--- a/sources/advertisements/VASTParserTests.swift
+++ b/sources/advertisements/VASTParserTests.swift
@@ -25,7 +25,7 @@ class VASTParserTests: XCTestCase {
         let vast = getVAST(atPath: "VAST1")
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail() }
         guard case let .inline(inlineModel) = model else { return XCTFail() }
-        guard let url = inlineModel.mediaFiles.first?.url.absoluteString else { return XCTFail() }
+        guard let url = inlineModel.videos.first?.url.absoluteString else { return XCTFail() }
         XCTAssertEqual(url,
             "https://dev.example.com/videos/2018/video_example_1280x720.mp4")
         XCTAssertEqual(inlineModel.id, "4203085")
@@ -36,7 +36,7 @@ class VASTParserTests: XCTestCase {
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail() }
         guard case let .inline(inlineModel) = model else { return XCTFail() }
         
-        XCTAssertEqual(inlineModel.mediaFiles.first?.url.absoluteString,
+        XCTAssertEqual(inlineModel.videos.first?.url.absoluteString,
                        "http://localhost:3000/adasset/1331/229/7969/lo.mp4")
     }
     
@@ -62,7 +62,7 @@ class VASTParserTests: XCTestCase {
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail("Failed to parse VAST VPAID xml") }
         guard case let .inline(vpaidModel) = model else { return XCTFail() }
         let expectedURLString = "http://localhost:3000/vpaid/6/video.js"
-        XCTAssertEqual(vpaidModel.mediaFiles.first?.url.absoluteString, expectedURLString)
+        XCTAssertEqual(vpaidModel.videos.first?.url.absoluteString, expectedURLString)
     }
     
     func testParseAdVerification() {

--- a/sources/advertisements/VASTParserTests.swift
+++ b/sources/advertisements/VASTParserTests.swift
@@ -25,7 +25,7 @@ class VASTParserTests: XCTestCase {
         let vast = getVAST(atPath: "VAST1")
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail() }
         guard case let .inline(inlineModel) = model else { return XCTFail() }
-        guard let url = inlineModel.videos.first?.url.absoluteString else { return XCTFail() }
+        guard let url = inlineModel.mp4MediaFiles.first?.url.absoluteString else { return XCTFail() }
         XCTAssertEqual(url,
             "https://dev.example.com/videos/2018/video_example_1280x720.mp4")
         XCTAssertEqual(inlineModel.id, "4203085")
@@ -36,7 +36,7 @@ class VASTParserTests: XCTestCase {
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail() }
         guard case let .inline(inlineModel) = model else { return XCTFail() }
         
-        XCTAssertEqual(inlineModel.videos.first?.url.absoluteString,
+        XCTAssertEqual(inlineModel.mp4MediaFiles.first?.url.absoluteString,
                        "http://localhost:3000/adasset/1331/229/7969/lo.mp4")
     }
     
@@ -62,7 +62,7 @@ class VASTParserTests: XCTestCase {
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail("Failed to parse VAST VPAID xml") }
         guard case let .inline(vpaidModel) = model else { return XCTFail() }
         let expectedURLString = "http://localhost:3000/vpaid/6/video.js"
-        XCTAssertEqual(vpaidModel.videos.first?.url.absoluteString, expectedURLString)
+        XCTAssertEqual(vpaidModel.vpaidMediaFiles.first?.url.absoluteString, expectedURLString)
     }
     
     func testParseAdVerification() {

--- a/sources/advertisements/VRM New Core/Controllers/FinalResultDispatchControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/FinalResultDispatchControllerTest.swift
@@ -28,12 +28,12 @@ class FinalResultDispatchControllerTest: XCTestCase {
                                                                    name: nil,
                                                                    cpm: nil))
         let inlineVAST = PlayerCore.Ad.VASTModel(adVerifications: [],
-                                                 mediaFiles: [.init(url: URL(string:"http://test.mp4")!,
-                                                                    type: .mp4,
-                                                                    width: 1,
-                                                                    height: 1,
-                                                                    scalable: true,
-                                                                    maintainAspectRatio: true)],
+                                                 mp4MediaFiles: [.init(url: URL(string:"http://test.mp4")!,
+                                                                        width: 1,
+                                                                        height: 1,
+                                                                        scalable: true,
+                                                                        maintainAspectRatio: true)],
+                                                 vpaidMediaFiles: [],
                                                  clickthrough: nil,
                                                  adParameters: "",
                                                  pixels: .init(), id: nil)

--- a/sources/advertisements/VRM New Core/Controllers/FinishVRMGroupProcessingControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/FinishVRMGroupProcessingControllerTest.swift
@@ -39,7 +39,8 @@ class FinishVRMGroupProcessingControllerTest: XCTestCase {
         group = VRMCore.Group(items: [urlItem, vastItem])
         
         adModel = .init(adVerifications: [],
-                        mediaFiles: [],
+                        mp4MediaFiles: [],
+                        vpaidMediaFiles: [],
                         clickthrough: nil,
                         adParameters: nil,
                         pixels: .init(),

--- a/sources/advertisements/VRM New Core/Controllers/ParseVRMItemControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/ParseVRMItemControllerTest.swift
@@ -43,7 +43,7 @@ class ParseVRMItemControllerTest: XCTestCase {
     
     func testSuccessfulParse() {
         let result = PlayerCore.Ad.VASTModel(adVerifications: [],
-                                             mediaFiles: [],
+                                             videos: [],
                                              clickthrough: nil,
                                              adParameters: nil,
                                              pixels: AdPixels(),

--- a/sources/advertisements/VRM New Core/Controllers/ParseVRMItemControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/ParseVRMItemControllerTest.swift
@@ -43,7 +43,8 @@ class ParseVRMItemControllerTest: XCTestCase {
     
     func testSuccessfulParse() {
         let result = PlayerCore.Ad.VASTModel(adVerifications: [],
-                                             videos: [],
+                                             mp4MediaFiles: [],
+                                             vpaidMediaFiles: [],
                                              clickthrough: nil,
                                              adParameters: nil,
                                              pixels: AdPixels(),

--- a/sources/advertisements/VRM New Core/Controllers/VRMProcessingControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMProcessingControllerTest.swift
@@ -37,7 +37,7 @@ class VRMProcessingControllerTest: XCTestCase {
                                                   adVerifications: [],
                                                   pixels: .init()))
         adModel = .init(adVerifications: [],
-                        mediaFiles: [],
+                        videos: [],
                         clickthrough: nil,
                         adParameters: nil,
                         pixels: .init(),

--- a/sources/advertisements/VRM New Core/Controllers/VRMProcessingControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMProcessingControllerTest.swift
@@ -37,7 +37,8 @@ class VRMProcessingControllerTest: XCTestCase {
                                                   adVerifications: [],
                                                   pixels: .init()))
         adModel = .init(adVerifications: [],
-                        videos: [],
+                        mp4MediaFiles: [],
+                        vpaidMediaFiles: [],
                         clickthrough: nil,
                         adParameters: nil,
                         pixels: .init(),

--- a/sources/advertisements/VRM New Core/Controllers/VRMSelectFinalResultControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMSelectFinalResultControllerTest.swift
@@ -27,14 +27,14 @@ class VRMSelectFinalResultControllerTest: XCTestCase {
         sut = VRMSelectFinalResultController(dispatch: dispatch)
         
         adModel1 = .init(adVerifications: [],
-                        mediaFiles: [],
+                        videos: [],
                         clickthrough: nil,
                         adParameters: nil,
                         pixels: .init(),
                         id: "id1")
         
         adModel2 = .init(adVerifications: [],
-                         mediaFiles: [],
+                         videos: [],
                          clickthrough: nil,
                          adParameters: nil,
                          pixels: .init(),

--- a/sources/advertisements/VRM New Core/Controllers/VRMSelectFinalResultControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMSelectFinalResultControllerTest.swift
@@ -27,14 +27,16 @@ class VRMSelectFinalResultControllerTest: XCTestCase {
         sut = VRMSelectFinalResultController(dispatch: dispatch)
         
         adModel1 = .init(adVerifications: [],
-                        videos: [],
+                         mp4MediaFiles: [],
+                         vpaidMediaFiles: [],
                         clickthrough: nil,
                         adParameters: nil,
                         pixels: .init(),
                         id: "id1")
         
         adModel2 = .init(adVerifications: [],
-                         videos: [],
+                         mp4MediaFiles: [],
+                         vpaidMediaFiles: [],
                          clickthrough: nil,
                          adParameters: nil,
                          pixels: .init(),

--- a/sources/advertisements/VerifyBuldTests.swift
+++ b/sources/advertisements/VerifyBuldTests.swift
@@ -12,12 +12,10 @@ class VerifyBuldTests: XCTestCase {
         let url = URL(string: "https://example.com")!
         let model = PlayerCore.Ad.VASTModel(
             adVerifications: [],
-            videos: [.vpaid(Ad.VASTModel.MediaFile(url: url,
-                                                 width: 100,
-                                                 height: 100,
-                                                 scalable: false,
-                                                 maintainAspectRatio: true))
-            ],
+            mp4MediaFiles: [],
+            vpaidMediaFiles: [Ad.VASTModel.VPAIDMediaFile(url: url,
+                                                          scalable: false,
+                                                          maintainAspectRatio: true)],
             clickthrough: nil,
             adParameters: "",
             pixels: AdPixels(impression: [],

--- a/sources/advertisements/VerifyBuldTests.swift
+++ b/sources/advertisements/VerifyBuldTests.swift
@@ -12,13 +12,11 @@ class VerifyBuldTests: XCTestCase {
         let url = URL(string: "https://example.com")!
         let model = PlayerCore.Ad.VASTModel(
             adVerifications: [],
-            mediaFiles: [
-                Ad.VASTModel.MediaFile(url: url,
-                                       type: .vpaid,
-                                       width: 100,
-                                       height: 100,
-                                       scalable: false,
-                                       maintainAspectRatio: true)
+            videos: [.vpaid(Ad.VASTModel.MediaFile(url: url,
+                                                 width: 100,
+                                                 height: 100,
+                                                 scalable: false,
+                                                 maintainAspectRatio: true))
             ],
             clickthrough: nil,
             adParameters: "",

--- a/sources/player/PlayerActionsJSONTests.swift
+++ b/sources/player/PlayerActionsJSONTests.swift
@@ -6,41 +6,6 @@ import CoreMedia
 import PlayerCore
 @testable import VerizonVideoPartnerSDK
 
-extension PlayerCore.AdPixels: Equatable {
-    public static func ==(lhs: PlayerCore.AdPixels, rhs: PlayerCore.AdPixels) -> Bool {
-        guard lhs.clickTracking == rhs.clickTracking else { return false }
-        guard lhs.complete == rhs.complete else { return false }
-        guard lhs.creativeView == rhs.creativeView else { return false }
-        guard lhs.error == rhs.error else { return false }
-        guard lhs.firstQuartile == rhs.firstQuartile else { return false }
-        guard lhs.impression == rhs.impression else { return false }
-        guard lhs.midpoint == rhs.midpoint else { return false }
-        guard lhs.pause == rhs.pause else { return false }
-        guard lhs.resume == rhs.resume else { return false }
-        guard lhs.start == rhs.start else { return false }
-        guard lhs.thirdQuartile == rhs.thirdQuartile else { return false }
-        
-        return true
-    }
-}
-
-extension PlayerCore.Ad.VASTModel: Equatable {
-    public static func ==(lhs: PlayerCore.Ad.VASTModel, rhs: PlayerCore.Ad.VASTModel) -> Bool {
-        guard lhs.mediaFiles.count == rhs.mediaFiles.count else { return false }
-        for index in 0..<lhs.mediaFiles.count {
-            let lmf = lhs.mediaFiles[index]
-            let rmf = rhs.mediaFiles[index]
-            guard lhs.id == rhs.id else { return false }
-            guard lhs.clickthrough == rhs.clickthrough else { return false }
-            guard lmf.maintainAspectRatio == rmf.maintainAspectRatio else { return false }
-            guard lmf.url == rmf.url else { return false }
-            guard lhs.pixels == rhs.pixels else { return false }
-            guard lmf.scalable == rmf.scalable else { return false }
-        }
-        return true
-    }
-}
-
 extension VideoSelector: Equatable {
     public static func ==(lhs: VideoSelector, rhs: VideoSelector) -> Bool {
         return lhs.index == rhs.index


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- VAST model now contains two structs for vpaid and mp4 instead of enum, so I've updated parsing and all other parts in code for the latest changes.

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
