### PR TITLE
Fix parsing of int and double values

### DIFF
--- a/sources/video provider/dictionary parser/Dictionary+ParseJSON.swift
+++ b/sources/video provider/dictionary parser/Dictionary+ParseJSON.swift
@@ -23,6 +23,18 @@ extension Parsable {
     }
 }
 
+extension Parsable where Self == Double {
+    static func parse(from object: Any) throws -> Double {
+        if let doubleResult = object as? Double {
+            return doubleResult
+        } else if let intResult = object as? Int {
+            return Double(intResult)
+        } else {
+            throw ParseError.cannotConvert(value: object, toType: Self.self)
+        }
+    }
+}
+
 extension String: Parsable {}
 extension Int: Parsable {}
 extension Int64: Parsable {}

--- a/sources/video provider/dictionary parser/DictionaryParseJSONTests.swift
+++ b/sources/video provider/dictionary parser/DictionaryParseJSONTests.swift
@@ -2,6 +2,7 @@
 //  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
 
 import XCTest
+import Nimble
 @testable import VerizonVideoPartnerSDK
 
 class DictionaryParseJSONTests: XCTestCase {
@@ -66,5 +67,36 @@ class DictionaryParseJSONTests: XCTestCase {
             XCTAssertEqual(object.field2, "value2")
             XCTAssertEqual(object.field3, nil)
         } catch { XCTFail() }
+    }
+    
+    func testParseIntValueAsDoubleShouldBeAllowed() {
+        let intValue = 1
+        let json = ["value": intValue]
+        
+        let doubleValue: Double? = try? json.parse("value")
+        expect(doubleValue) == 1.0
+    }
+    
+    func testParseIntValueAsIntShouldBeAllowed() {
+        let intValue = 1
+        let json = ["value": intValue]
+        
+        let parsedInt: Int? = try? json.parse("value")
+        expect(parsedInt) == 1
+    }
+    
+    func testParseDoubleAsIntShouldBeRejected() {
+        let doubleValue = 1.5
+        let json = ["value": doubleValue]
+        
+        expect(try json.parse("value") as Int).to(throwError())
+    }
+    
+    func testParseDoubleAsDoubleShouldBeAllowed() {
+        let doubleValue = 1.5
+        let json = ["value": doubleValue]
+        
+        let parsedInt: Double? = try? json.parse("value")
+        expect(parsedInt) == 1.5
     }
 }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
Updated parsing
* allowed parsing of int value if expected double. It will be converted to double
* rejected parsing of double value if expected int.

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
