### PR TITLE
Added controller to choose creative for current viewport

### DIFF
--- a/VerizonVideoPartnerSDK.xcodeproj/project.pbxproj
+++ b/VerizonVideoPartnerSDK.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		067209EB21B6BF3E0086CDBE /* OpenMeasurementControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 067209B921B6BD9A0086CDBE /* OpenMeasurementControllerTests.swift */; };
 		067209EC21B6BF440086CDBE /* BufferingDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 067209D321B6BE320086CDBE /* BufferingDetectorTests.swift */; };
 		067209F221B6CCAE0086CDBE /* BufferingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 067209D221B6BE320086CDBE /* BufferingDetector.swift */; };
+		068B16A4220223FD003ABD69 /* MP4AdCreativeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068B16A1220223FD003ABD69 /* MP4AdCreativeController.swift */; };
+		068B16A5220223FD003ABD69 /* MP4AdCreativeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068B16A1220223FD003ABD69 /* MP4AdCreativeController.swift */; };
+		068B16A622022429003ABD69 /* MP4AdCreativeControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068B16A0220223FD003ABD69 /* MP4AdCreativeControllerTest.swift */; };
 		069DC3E820EA9BA600D70B28 /* VPAIDEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069DC3E620EA9BA600D70B28 /* VPAIDEvents.swift */; };
 		069DC48420EA9EC400D70B28 /* VPAIDEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069DC3E620EA9BA600D70B28 /* VPAIDEvents.swift */; };
 		06B13EF22090AB13009A6645 /* AdViewTimeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B13EF12090AB12009A6645 /* AdViewTimeDetector.swift */; };
@@ -464,6 +467,8 @@
 		067209D921B6BE710086CDBE /* VASTVerificationInExtension.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = VASTVerificationInExtension.xml; sourceTree = "<group>"; };
 		067209DA21B6BE710086CDBE /* VASTWrapperWithExtension.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = VASTWrapperWithExtension.xml; sourceTree = "<group>"; };
 		067209E221B6BF070086CDBE /* OMSDK_Oath2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OMSDK_Oath2.framework; sourceTree = "<group>"; };
+		068B16A0220223FD003ABD69 /* MP4AdCreativeControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MP4AdCreativeControllerTest.swift; sourceTree = "<group>"; };
+		068B16A1220223FD003ABD69 /* MP4AdCreativeController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MP4AdCreativeController.swift; sourceTree = "<group>"; };
 		069DC3E620EA9BA600D70B28 /* VPAIDEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VPAIDEvents.swift; sourceTree = "<group>"; };
 		06B13EF12090AB12009A6645 /* AdViewTimeDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdViewTimeDetector.swift; sourceTree = "<group>"; };
 		06B13EF42090AB1B009A6645 /* AdViewTimeDetectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdViewTimeDetectorTests.swift; sourceTree = "<group>"; };
@@ -736,6 +741,15 @@
 				067209B821B6BD9A0086CDBE /* OpenMeasurementServiceScript.swift */,
 			);
 			path = "open measurement";
+			sourceTree = "<group>";
+		};
+		068B169C2202238B003ABD69 /* creative controllers */ = {
+			isa = PBXGroup;
+			children = (
+				068B16A1220223FD003ABD69 /* MP4AdCreativeController.swift */,
+				068B16A0220223FD003ABD69 /* MP4AdCreativeControllerTest.swift */,
+			);
+			path = "creative controllers";
 			sourceTree = "<group>";
 		};
 		069DC3DF20EA9B8C00D70B28 /* vpaid event */ = {
@@ -1050,6 +1064,7 @@
 		DE1FB28A1CE359B300B99941 /* advertisements */ = {
 			isa = PBXGroup;
 			children = (
+				068B169C2202238B003ABD69 /* creative controllers */,
 				06F8DBB621C2A2A00019021D /* VRM New Core */,
 				DE1FD9D01CE7759E00C0B7BC /* process ad item */,
 				DE1685D71CE7308500492A90 /* vast parser */,
@@ -1823,6 +1838,7 @@
 				50A11DE61D59D7E000F4A068 /* VASTModel.swift in Sources */,
 				50A11DEB1D59D7E000F4A068 /* AdMetrics.swift in Sources */,
 				E2B0062021CD265000B72485 /* FetchVRMItemController.swift in Sources */,
+				068B16A5220223FD003ABD69 /* MP4AdCreativeController.swift in Sources */,
 				50E6E456208F94EF003B0F4E /* UserActionInitiated.swift in Sources */,
 				50A11DEC1D59D7E000F4A068 /* VASTWrapperProcessor.swift in Sources */,
 				50D629D420237BA5000B2F8F /* TrackingPixelsConnector_Ad.swift in Sources */,
@@ -1866,6 +1882,7 @@
 				DE4C51E11C80D43200BFFB0B /* TrackingPixelsConnector.swift in Sources */,
 				50D629D320237BA5000B2F8F /* TrackingPixelsConnector_Ad.swift in Sources */,
 				DE07F0511EF9956B00C8E9F2 /* ReporterTracer.swift in Sources */,
+				068B16A4220223FD003ABD69 /* MP4AdCreativeController.swift in Sources */,
 				DE3DA42B1E55D9A900D34880 /* VVPSDKPlugins.swift in Sources */,
 				50FEC3FF1DDF58A20013DA99 /* NonEmptyString.swift in Sources */,
 				DE4C51C41C80918E00BFFB0B /* VideoTimeDetector.swift in Sources */,
@@ -2001,6 +2018,7 @@
 				0672086F2125A7AF007C07D7 /* ObserverTests.swift in Sources */,
 				E241041C21C4078E00036290 /* StartVRMGroupProcessingControllerTest.swift in Sources */,
 				508748271C80753800F2511A /* DictionaryParseJSONTests.swift in Sources */,
+				068B16A622022429003ABD69 /* MP4AdCreativeControllerTest.swift in Sources */,
 				505136171C90A35100629078 /* UserActionInitiatedTests.swift in Sources */,
 				E22B6AD921EF852800D480A0 /* VRMProcessingControllerTest.swift in Sources */,
 				FE940A001F3DD56600A867CD /* IntentDetectorTests.swift in Sources */,

--- a/sources/advertisements/creative controllers/MP4AdCreativeController.swift
+++ b/sources/advertisements/creative controllers/MP4AdCreativeController.swift
@@ -1,0 +1,46 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import Foundation
+import PlayerCore
+
+final class MP4AdCreativeController {
+    
+    let dispatch: (PlayerCore.Action) -> Void
+    private var processedCreatives = Set<PlayerCore.AdCreative>()
+    
+    init(dispatch: @escaping (PlayerCore.Action) -> Void) {
+        self.dispatch = dispatch
+    }
+    
+    
+    func process(state: State) {
+        process(adCreative: state.selectedAdCreative,
+                viewport: state.viewport.dimensions,
+                id: UUID())
+    }
+    
+    func process(adCreative: PlayerCore.AdCreative, viewport: CGSize?, id: UUID) {
+        guard let dimensions = viewport else { return }
+        guard case .mp4(let creatives) = adCreative else { return }
+        guard processedCreatives.contains(adCreative) == false else { return }
+        processedCreatives.insert(adCreative)
+        
+        guard creatives.count > 1 else {
+            guard let creative = creatives.first else { fatalError("Failed to unwrap existing value") }
+            dispatch(PlayerCore.showMP4Ad(creative: creative, id: id))
+            return
+        }
+        var diff: CGFloat = CGFloat.greatestFiniteMagnitude;
+        var result: PlayerCore.AdCreative.MP4? = nil
+        for creative in creatives {
+            let newDiff = abs(dimensions.width * dimensions.height - CGFloat(creative.width) * CGFloat(creative.height));
+            if newDiff < diff {
+                diff = newDiff;
+                result = creative;
+            }
+        }
+        guard let adCreative = result else { return }
+        dispatch(PlayerCore.showMP4Ad(creative: adCreative, id: id))
+    }
+}

--- a/sources/advertisements/creative controllers/MP4AdCreativeControllerTest.swift
+++ b/sources/advertisements/creative controllers/MP4AdCreativeControllerTest.swift
@@ -1,0 +1,102 @@
+//  Copyright 2018, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import XCTest
+@testable import VerizonVideoPartnerSDK
+@testable import PlayerCore
+class MP4AdCreativeControllerTest: XCTestCase {
+
+    let recorder = Recorder()
+    var sut: MP4AdCreativeController!
+    var id: UUID!
+    
+    
+    override func setUp() {
+        let comparator = ActionComparator<ShowMP4Ad> {
+            $0.creative == $1.creative && $0.id == $1.id
+        }
+        let dispatch = recorder.hook("hook", cmp: comparator.compare)
+        sut = MP4AdCreativeController(dispatch: dispatch)
+        id = UUID()
+    }
+    
+    func testSingleMP4Creative() {
+        recorder.record {
+            sut.process(adCreative: .mp4([getMP4Creative(width: 320, height: 240)]),
+                        viewport: CGSize(width: 480, height: 320),
+                        id: id)
+            sut.process(adCreative: .mp4([getMP4Creative(width: 320, height: 240)]),
+                        viewport: CGSize(width: 480, height: 320),
+                        id: UUID())
+            
+        }
+        
+        recorder.verify {
+            sut.dispatch(PlayerCore.ShowMP4Ad(creative: getMP4Creative(width: 320, height: 240), id: id))
+        }
+    }
+    
+    func testIncorectCreative() {
+        recorder.record {
+            sut.process(adCreative: .none, viewport: CGSize(width: 480, height: 320), id: id)
+            sut.process(adCreative: .vpaid([]), viewport: CGSize(width: 480, height: 320), id: id)
+        }
+        
+        recorder.verify {}
+    }
+    
+    func testDispatchAppropriateAdBySize() {
+        recorder.record {
+            sut.process(adCreative: .mp4([getMP4Creative(width: 640, height: 480),
+                                          getMP4Creative(width: 640, height: 360),
+                                          getMP4Creative(width: 320, height: 180)]),
+                        viewport: CGSize(width: 520, height: 380),
+                        id: id)
+        }
+        
+        recorder.verify {
+            sut.dispatch(PlayerCore.ShowMP4Ad(creative: getMP4Creative(width: 640, height: 360), id: id))
+        }
+    }
+    
+    func testDispatchTheSmallestAdBySize() {
+        recorder.record {
+            sut.process(adCreative: .mp4([getMP4Creative(width: 640, height: 480),
+                                          getMP4Creative(width: 640, height: 360),
+                                          getMP4Creative(width: 320, height: 180)]),
+                        viewport: CGSize(width: 240, height: 160),
+                        id: id)
+        }
+        
+        recorder.verify {
+            sut.dispatch(PlayerCore.ShowMP4Ad(creative: getMP4Creative(width: 320, height: 180), id: id))
+        }
+    }
+    
+    func testDispatchTheBiggestAdBySize() {
+        recorder.record {
+            sut.process(adCreative: .mp4([getMP4Creative(width: 640, height: 480),
+                                          getMP4Creative(width: 640, height: 360),
+                                          getMP4Creative(width: 320, height: 180)]),
+                        viewport: CGSize(width: 896, height: 414),
+                        id: id)
+        }
+        
+        recorder.verify {
+            sut.dispatch(PlayerCore.ShowMP4Ad(creative: getMP4Creative(width: 640, height: 480), id: id))
+        }
+    }
+}
+
+func getMP4Creative(width: Int, height: Int) -> AdCreative.MP4 {
+    let testURL = URL(string: "https://")!
+    return AdCreative.MP4(url: testURL,
+                          clickthrough: testURL,
+                          pixels: AdPixels(impression: [], error: [], clickTracking: [], creativeView: [], start: [], firstQuartile: [], midpoint: [], thirdQuartile: [], complete: [], pause: [], resume: [], skip: [], mute: [], unmute: [], acceptInvitation: [], acceptInvitationLinear: [], close: [], closeLinear: [], collapse: []),
+                          id: "",
+                          width: width,
+                          height: height,
+                          scalable: false,
+                          maintainAspectRatio: true)
+}
+


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Created a controller that expects `mp4` creatives and takes out of the array the most appropriate creative for the current `viewport`.
- It will dispatch a new action from PlayerCore, but it is not yet connected to our SDK.

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
