### PR TITLE
ad-engine-request should be fired only for item, not wrapper

### DIFF
--- a/sources/metrics/detectors/vrm/AdEngineRequestDetector.swift
+++ b/sources/metrics/detectors/vrm/AdEngineRequestDetector.swift
@@ -13,7 +13,7 @@ extension Detectors {
             let transactionId: String?
         }
         
-        private var processedCandidates = Set<ScheduledVRMItems.Candidate>()
+        private var processedItems = Set<VRMCore.Item>()
         
         func process(state: PlayerCore.State) -> [Result] {
             return process(transactionId: state.vrmResponse?.transactionId,
@@ -24,21 +24,12 @@ extension Detectors {
                      scheduledItems: [VRMCore.Item: Set<ScheduledVRMItems.Candidate>]) -> [Result] {
             guard scheduledItems.isEmpty == false else { return [] }
             
-            struct NormalizedScheduledItem {
-                let item: VRMCore.Item
-                let candidate: ScheduledVRMItems.Candidate
-            }
-            
-            return scheduledItems
-                .reduce(into: []) { result, pair in
-                       return pair.value.forEach { candidate in
-                            result.append(NormalizedScheduledItem(item: pair.key, candidate: candidate))
-                        }
-                }.filter { normalized in
-                    processedCandidates.contains(normalized.candidate) == false
-                }.compactMap { normalized in
-                    processedCandidates.insert(normalized.candidate)
-                    return Result(adInfo: .init(metaInfo: normalized.item.metaInfo), transactionId: transactionId)
+            return Set(scheduledItems.keys)
+                .subtracting(processedItems)
+                .compactMap { item in
+                    processedItems.insert(item)
+                    return Result(adInfo: Ad.Metrics.Info(metaInfo: item.metaInfo),
+                                  transactionId: transactionId)
             }
         }
     }

--- a/sources/metrics/detectors/vrm/AdEngineRequestDetectorTest.swift
+++ b/sources/metrics/detectors/vrm/AdEngineRequestDetectorTest.swift
@@ -42,18 +42,23 @@ class AdEngineRequestDetectorTest: XCTestCase {
     
     func testCorrectDetection() {
         let queue: [VRMCore.Item: Set<ScheduledVRMItems.Candidate>] = [firstItem: Set([firstCandidate])]
-        var result = detector.process(transactionId: "", scheduledItems: queue)
+        let result = detector.process(transactionId: "", scheduledItems: queue)
         
+        guard let first = result.first else {
+            XCTFail("result have to contain 1 object in case of one non tracked item")
+            return
+        }
         XCTAssertEqual(result.count, 1)
-        XCTAssertEqual(result[0].adInfo.engineType,    firstMetainfo.engineType)
-        XCTAssertEqual(result[0].adInfo.ruleId,        firstMetainfo.ruleId)
-        XCTAssertEqual(result[0].adInfo.ruleCompanyId, firstMetainfo.ruleCompanyId)
-        XCTAssertEqual(result[0].adInfo.vendor,        firstMetainfo.vendor)
-        XCTAssertEqual(result[0].adInfo.name,          firstMetainfo.name)
-        XCTAssertEqual(result[0].adInfo.cpm,           firstMetainfo.cpm)
+        
+        XCTAssertEqual(first.adInfo.engineType,    firstMetainfo.engineType)
+        XCTAssertEqual(first.adInfo.ruleId,        firstMetainfo.ruleId)
+        XCTAssertEqual(first.adInfo.ruleCompanyId, firstMetainfo.ruleCompanyId)
+        XCTAssertEqual(first.adInfo.vendor,        firstMetainfo.vendor)
+        XCTAssertEqual(first.adInfo.name,          firstMetainfo.name)
+        XCTAssertEqual(first.adInfo.cpm,           firstMetainfo.cpm)
     }
     
-    func testDoubleDetectSameCandidate() {
+    func testDoubleDetectSameItem() {
         let queue: [VRMCore.Item: Set<ScheduledVRMItems.Candidate>] = [firstItem: Set([firstCandidate])]
         var result = detector.process(transactionId: "", scheduledItems: queue)
         XCTAssertEqual(result.count, 1)
@@ -65,7 +70,7 @@ class AdEngineRequestDetectorTest: XCTestCase {
     func testDetectingTwoCandidates() {
         let queue: [VRMCore.Item: Set<ScheduledVRMItems.Candidate>] = [firstItem: Set([firstCandidate, secondCandidate])]
         var result = detector.process(transactionId: "", scheduledItems: queue)
-        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.count, 1)
         
         result = detector.process(transactionId: "", scheduledItems: queue)
         XCTAssertTrue(result.isEmpty)
@@ -91,6 +96,6 @@ class AdEngineRequestDetectorTest: XCTestCase {
         queue[firstItem] = candidates
         
         result = detector.process(transactionId: "", scheduledItems: queue)
-        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.count, 0)
     }
 }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

In case of unwrapping an item haven't to send any `ad-engine-request`

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.