### PR TITLE
Update timeout controller to improve testability

### DIFF
--- a/sources/VVPSDK.swift
+++ b/sources/VVPSDK.swift
@@ -431,10 +431,13 @@ public struct VVPSDK {
                                                                 self.vrmProvider.requestAds(with: createRequest(url))
             }
             let processingController = VRMProcessingController(maxRedirectCount: maxRedirectCount, dispatch: dispatcher)
-            let createSoftTimeoutTimer = { Timer(duration: softTimeout){ dispatcher(PlayerCore.VRMCore.softTimeoutReached()) } }
-            let createHardTimeoutTimer = { Timer(duration: hardTimeout){ dispatcher(PlayerCore.VRMCore.hardTimeoutReached()) } }
-            let timeoutController = VRMTimeoutController(softTimeoutTimerFactory: createSoftTimeoutTimer,
-                                                         hardTimeoutTimerFactory: createHardTimeoutTimer)
+           
+            let timeoutController = VRMTimeoutController(dispatch: dispatcher,
+                                                         softTimeoutTimerFactory: { onFire in
+                                                            Timer(duration: softTimeout, fire: onFire) },
+                                                         hardTimeoutTimerFactory: { onFire in
+                                                            Timer(duration: hardTimeout, fire: onFire) })
+            
             let selectFinalResult = VRMSelectFinalResultController(dispatch: dispatcher)
             let maxAdSearchTimeController = MaxAdSearchTimeController { requestID in
                 Timer(duration: maxAdSearchTime) {

--- a/sources/advertisements/VRM New Core/Controllers/VRMProcessingController.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMProcessingController.swift
@@ -19,15 +19,11 @@ final class VRMProcessingController {
     func process(with state: PlayerCore.State) {
         process(parsingResultQueue: state.vrmParsingResult.parsedVASTs,
                 scheduledVRMItems: state.vrmScheduledItems.items,
-                currentGroup: state.vrmCurrentGroup.currentGroup,
-                timeout: state.vrmProcessingTimeout,
                 isMaxAdSearchTimeoutReached: state.vrmMaxAdSearchTimeout.isReached)
     }
     
     func process(parsingResultQueue: [VRMCore.Item: VRMParsingResult.Result],
                  scheduledVRMItems: [VRMCore.Item: Set<ScheduledVRMItems.Candidate>],
-                 currentGroup: VRMCore.Group?,
-                 timeout: VRMProcessingTimeout,
                  isMaxAdSearchTimeoutReached: Bool) {
         guard isMaxAdSearchTimeoutReached == false else {
             return
@@ -38,11 +34,7 @@ final class VRMProcessingController {
                 dispatchedResults.contains(result) == false
             }.forEach { item, result in
                 
-                if currentGroup == nil ||
-                    currentGroup?.items.contains(item) == false ||
-                    timeout == .hard {
-                    dispatch(VRMCore.timeoutError(item: item))
-                } else if case .inline(let vast) = result.vastModel {
+                if case .inline(let vast) = result.vastModel {
                     dispatch(VRMCore.selectInlineVAST(item: item, inlineVAST: vast))
                 } else if case .wrapper(let wrapper) = result.vastModel {
                     guard let count = scheduledVRMItems[item]?.count else {

--- a/sources/advertisements/VRM New Core/Controllers/VRMTimeoutController.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMTimeoutController.swift
@@ -6,35 +6,60 @@ import PlayerCore
 
 final class VRMTimeoutController {
     
-    let softTimeoutTimerFactory: () -> Cancellable
-    let hardTimeoutTimerFactory: () -> Cancellable
+    typealias OnFire = (()->())
+    typealias TimerFactory = (@escaping OnFire) -> Cancellable
     
-    private var softTimeoutTimer: Cancellable?
-    private var hardTimeoutTimer: Cancellable?
+    private struct TimerHolder {
+        let soft: Cancellable
+        let hard: Cancellable
+        
+        func cancel() {
+            soft.cancel()
+            hard.cancel()
+        }
+    }
+    
+    let dispatch: (PlayerCore.Action) -> Void
+    let softTimeoutTimerFactory: TimerFactory
+    let hardTimeoutTimerFactory: TimerFactory
+    
+    private var timeoutTimerHolder: TimerHolder?
     
     private var startedGroups = Set<VRMCore.Group.ID>()
+    private var currentFetchingQueue = [VRMCore.Item]()
     
-    init(softTimeoutTimerFactory: @escaping () -> Cancellable,
-         hardTimeoutTimerFactory: @escaping () -> Cancellable) {
+    init(dispatch: @escaping (PlayerCore.Action) -> Void,
+         softTimeoutTimerFactory: @escaping TimerFactory,
+         hardTimeoutTimerFactory: @escaping TimerFactory) {
+        self.dispatch = dispatch
         self.softTimeoutTimerFactory = softTimeoutTimerFactory
         self.hardTimeoutTimerFactory = hardTimeoutTimerFactory
     }
     
     func process(with state: PlayerCore.State) {
-        process(currentGroup: state.vrmCurrentGroup.currentGroup)
+        process(currentGroup: state.vrmCurrentGroup.currentGroup,
+                fetchingQueue: state.vrmFetchItemsQueue.candidates.map{$0.parentItem})
     }
     
-    func process(currentGroup: VRMCore.Group?) {
+    func process(currentGroup: VRMCore.Group?,
+                 fetchingQueue: [VRMCore.Item]) {
         guard let currentGroup = currentGroup else {
-            softTimeoutTimer?.cancel()
-            hardTimeoutTimer?.cancel()
+            timeoutTimerHolder?.cancel()
+            currentFetchingQueue = []
             return
         }
-        
+        currentFetchingQueue = fetchingQueue
         if startedGroups.contains(currentGroup.id) == false {
             startedGroups.insert(currentGroup.id)
-            softTimeoutTimer = softTimeoutTimerFactory()
-            hardTimeoutTimer = hardTimeoutTimerFactory()
+            
+            let softTimeoutTimer = softTimeoutTimerFactory({
+                self.dispatch(PlayerCore.VRMCore.softTimeoutReached())
+            })
+            let hardTimeoutTimer = hardTimeoutTimerFactory({
+                self.dispatch(PlayerCore.VRMCore.hardTimeoutReached(items: self.currentFetchingQueue))
+            })
+            
+            timeoutTimerHolder = TimerHolder(soft: softTimeoutTimer, hard: hardTimeoutTimer)
         }
     }
 }

--- a/sources/advertisements/VRM New Core/Controllers/VRMTimeoutControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMTimeoutControllerTest.swift
@@ -7,38 +7,83 @@ import XCTest
 
 
 class VRMTimeoutControllerTest: XCTestCase {
+    
+    let softTimeoutActionComparator = ActionComparator<VRMCore.SoftTimeout> { _,_ in
+        return true
+    }
+    let hardTimeoutActionComparator = ActionComparator<VRMCore.HardTimeout> {
+        return $0.items == $1.items
+    }
+    
+    let recorder = Recorder()
+    
     var numberOfSoftInitCall: Int!
     var numberOfHardInitCall: Int!
     
     var softTimer: MockTimer!
     var hardTimer: MockTimer!
     
+    var softFactory: VRMTimeoutController.TimerFactory!
+    var hardFactory: VRMTimeoutController.TimerFactory!
+    
+    var onFireSoft: VRMTimeoutController.OnFire!
+    var onFireHard: VRMTimeoutController.OnFire!
+    
     var sut: VRMTimeoutController!
     
+    var item1: VRMCore.Item!
+    var item2: VRMCore.Item!
     override func setUp() {
         super.setUp()
+        item1 = VRMCore.Item(id: .init(),
+                             source: .vast(""),
+                             metaInfo: .init(engineType: nil,
+                                             ruleId: nil,
+                                             ruleCompanyId: nil,
+                                             vendor: "",
+                                             name: nil,
+                                             cpm: nil))
+        item2 = VRMCore.Item(id: .init(),
+                             source: .vast(""),
+                             metaInfo: .init(engineType: nil,
+                                             ruleId: nil,
+                                             ruleCompanyId: nil,
+                                             vendor: "",
+                                             name: nil,
+                                             cpm: nil))
+        
         softTimer = MockTimer()
         hardTimer = MockTimer()
-        let softFactory: () -> Cancellable = {
+        
+        softFactory = { onFire in
+            self.onFireSoft = onFire
             self.numberOfSoftInitCall += 1
             return self.softTimer
         }
-        let hardFactory: () -> Cancellable = {
+        hardFactory = { onFire in
+            self.onFireHard = onFire
             self.numberOfHardInitCall += 1
             return self.hardTimer
         }
-        
-        sut = VRMTimeoutController(softTimeoutTimerFactory: softFactory,
-                                   hardTimeoutTimerFactory: hardFactory)
         
         numberOfSoftInitCall = 0
         numberOfHardInitCall = 0
     }
     
+    override func tearDown() {
+        recorder.verify {}
+        recorder.clean()
+        super.tearDown()
+    }
+    
     func testFinishCurrentGroup() {
-        sut.process(currentGroup: VRMCore.Group(items: []))
+        sut = VRMTimeoutController(dispatch: {_ in},
+                                   softTimeoutTimerFactory: softFactory,
+                                   hardTimeoutTimerFactory: hardFactory)
         
-        sut.process(currentGroup: nil)
+        sut.process(currentGroup: VRMCore.Group(items: []), fetchingQueue: [])
+        
+        sut.process(currentGroup: nil, fetchingQueue: [])
         
         XCTAssertTrue(softTimer.didCancelCalled)
         XCTAssertTrue(hardTimer.didCancelCalled)
@@ -47,14 +92,54 @@ class VRMTimeoutControllerTest: XCTestCase {
     }
     
     func testCurrentGroupSecondTime() {
-        let currentGruop = VRMCore.Group(items: [])
+        sut = VRMTimeoutController(dispatch: {_ in},
+                                   softTimeoutTimerFactory: softFactory,
+                                   hardTimeoutTimerFactory: hardFactory)
+
         
-        sut.process(currentGroup: currentGruop)
-        sut.process(currentGroup: currentGruop)
+        let currentGruop = VRMCore.Group(items: [item1, item2])
+        
+        sut.process(currentGroup: currentGruop, fetchingQueue: [])
+        sut.process(currentGroup: currentGruop, fetchingQueue: [])
         
         XCTAssertFalse(softTimer.didCancelCalled)
         XCTAssertFalse(hardTimer.didCancelCalled)
         XCTAssertEqual(numberOfSoftInitCall, 1)
         XCTAssertEqual(numberOfHardInitCall, 1)
+    }
+    
+    func testSoftTimeoutReached() {
+        let group = VRMCore.Group(items: [])
+        let hook = recorder.hook("testSoftTimeoutReached", cmp: softTimeoutActionComparator.compare)
+        sut = VRMTimeoutController(dispatch: hook,
+                                   softTimeoutTimerFactory: softFactory,
+                                   hardTimeoutTimerFactory: hardFactory)
+        
+        recorder.record {
+            sut.process(currentGroup: group, fetchingQueue: [item1, item2])
+            onFireSoft()
+        }
+        
+        recorder.verify {
+            sut.dispatch(VRMCore.softTimeoutReached())
+        }
+    }
+    
+    func testHardTimeoutReached() {
+        let group = VRMCore.Group(items: [item1, item2])
+        let hook = recorder.hook("testHardTimeoutReached", cmp: hardTimeoutActionComparator.compare)
+        sut = VRMTimeoutController(dispatch: hook,
+                                   softTimeoutTimerFactory: softFactory,
+                                   hardTimeoutTimerFactory: hardFactory)
+        
+        recorder.record {
+            sut.process(currentGroup: group, fetchingQueue: [item1, item2])
+            sut.process(currentGroup: group, fetchingQueue: [item1])
+            onFireHard()
+        }
+        
+        recorder.verify {
+            sut.dispatch(VRMCore.hardTimeoutReached(items: [item1]))
+        }
     }
 }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Remove responsibility for detecting items which came after hard timeout from `VRMProcessingController` to `VRMTimeoutController`

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.