### PR TITLE
Fix issue with slot opp detector

### DIFF
--- a/sources/metrics/detectors/slot opportunity/SlotOpportunityDetectorTests.swift
+++ b/sources/metrics/detectors/slot opportunity/SlotOpportunityDetectorTests.swift
@@ -26,10 +26,16 @@ class SlotOpportunityDetectorTests: XCTestCase {
     }
     
     func testSessionChanageProcess() {
-        _ = sut.process(sessionID: UUID(), playbackStarted: true)
-        XCTAssertTrue(sut.playbackInitiated)
+        let firstAd = UUID()
+        let secondAd = UUID()
         
-        _ = sut.process(sessionID: UUID(), playbackStarted: false)
-        XCTAssertFalse(sut.playbackInitiated)
+        var result = sut.process(sessionID: firstAd, playbackStarted: true)
+        XCTAssertTrue(result)
+        
+        result = sut.process(sessionID: secondAd, playbackStarted: false)
+        XCTAssertFalse(result)
+        
+        result = sut.process(sessionID: secondAd, playbackStarted: true)
+        XCTAssertTrue(result)
     }
 }

--- a/sources/metrics/tracking pixels/TrackingPixelsConnector_Ad.swift
+++ b/sources/metrics/tracking pixels/TrackingPixelsConnector_Ad.swift
@@ -238,12 +238,10 @@ extension TrackingPixels.Connector {
             }
         }
         /* Slot Opportunity Detector */ do {
-            if let adSessionID = sessionID {
-                let slotDetected = adSlotOpportunityDetector.process(
-                    sessionID: adSessionID,
-                    playbackStarted: state.rate.adRate.stream || state.rate.contentRate.stream)
-                if slotDetected,
-                    let slot = slot {
+            if let adSessionID = sessionID,
+                let slot = slot {
+                let playbackStarted = state.rate.adRate.stream || state.rate.contentRate.stream
+                if adSlotOpportunityDetector.process( sessionID: adSessionID, playbackStarted: playbackStarted) {
                     reporter.slotOpportunity(videoIndex: state.playlist.currentIndex,
                                              slot: slot,
                                              transactionId: transactionId,

--- a/sources/player/PlayerProperties_Init.swift
+++ b/sources/player/PlayerProperties_Init.swift
@@ -270,7 +270,7 @@ extension Player.Properties {
         isSessionCompleted = state.playerSession.isCompleted
         isAutoplayEnabled = model.isAutoplayEnabled
         isPlaybackInitiated = state.playerSession.isStarted
-        adSessionID = state.adVRMManager.request.id ?? state.playbackSession.id
+        adSessionID = state.adVRMManager.request.id ?? state.vrmRequestStatus.request?.id ?? state.playbackSession.id
         vpaidDocument = model.vpaidSettings.document
         
     }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Slot opp didn't fire for videos with two and more ads.

* Moved check for slot value on the same level with adSession check.
* Update session id in props with new core value

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
