### PR TITLE
Added ad engine response detector

### DIFF
--- a/VerizonVideoPartnerSDK.xcodeproj/project.pbxproj
+++ b/VerizonVideoPartnerSDK.xcodeproj/project.pbxproj
@@ -296,6 +296,9 @@
 		E2604391220379740034FC48 /* VRMRequestDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2604390220379740034FC48 /* VRMRequestDetector.swift */; };
 		E2604392220379740034FC48 /* VRMRequestDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2604390220379740034FC48 /* VRMRequestDetector.swift */; };
 		E2604397220379F10034FC48 /* VRMRequestDetectorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2604396220379F10034FC48 /* VRMRequestDetectorTest.swift */; };
+		E26043FA220885B70034FC48 /* AdEngineResponseDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26043F5220885B60034FC48 /* AdEngineResponseDetector.swift */; };
+		E26043FB220885B70034FC48 /* AdEngineResponseDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26043F5220885B60034FC48 /* AdEngineResponseDetector.swift */; };
+		E26043FE220885C10034FC48 /* AdEngineResponseDetectorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26043F9220885B60034FC48 /* AdEngineResponseDetectorTest.swift */; };
 		E2629D07211228FA006ED117 /* TelemetryMetricsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2629D06211228FA006ED117 /* TelemetryMetricsTest.swift */; };
 		E2629D3C21147ECE006ED117 /* NoVpaidUrlFixture.json in Resources */ = {isa = PBXBuildFile; fileRef = E2629D3521147ECE006ED117 /* NoVpaidUrlFixture.json */; };
 		E287B08C21F884A900FC49AA /* VRMSelectFinalResultController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E287B08B21F884A900FC49AA /* VRMSelectFinalResultController.swift */; };
@@ -655,6 +658,8 @@
 		E257A9FA21C93F4A0016D35A /* VRMItemControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VRMItemControllerTest.swift; sourceTree = "<group>"; };
 		E2604390220379740034FC48 /* VRMRequestDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VRMRequestDetector.swift; sourceTree = "<group>"; };
 		E2604396220379F10034FC48 /* VRMRequestDetectorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VRMRequestDetectorTest.swift; sourceTree = "<group>"; };
+		E26043F5220885B60034FC48 /* AdEngineResponseDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdEngineResponseDetector.swift; sourceTree = "<group>"; };
+		E26043F9220885B60034FC48 /* AdEngineResponseDetectorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdEngineResponseDetectorTest.swift; sourceTree = "<group>"; };
 		E2629D06211228FA006ED117 /* TelemetryMetricsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TelemetryMetricsTest.swift; path = sources/telemetry/TelemetryMetricsTest.swift; sourceTree = "<group>"; };
 		E2629D3521147ECE006ED117 /* NoVpaidUrlFixture.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = NoVpaidUrlFixture.json; sourceTree = "<group>"; };
 		E287B08B21F884A900FC49AA /* VRMSelectFinalResultController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VRMSelectFinalResultController.swift; sourceTree = "<group>"; };
@@ -990,10 +995,12 @@
 			children = (
 				50C99D512010DAE90041B013 /* VRMDetector.swift */,
 				508A597D2010F97B00641398 /* VRMDetectorTests.swift */,
-				E2FD5AEB2203413E007EBE86 /* AdEngineRequestDetector.swift */,
-				E2FD5AEE2203414D007EBE86 /* AdEngineRequestDetectorTest.swift */,
 				E2604390220379740034FC48 /* VRMRequestDetector.swift */,
 				E2604396220379F10034FC48 /* VRMRequestDetectorTest.swift */,
+				E2FD5AEB2203413E007EBE86 /* AdEngineRequestDetector.swift */,
+				E2FD5AEE2203414D007EBE86 /* AdEngineRequestDetectorTest.swift */,
+				E26043F5220885B60034FC48 /* AdEngineResponseDetector.swift */,
+				E26043F9220885B60034FC48 /* AdEngineResponseDetectorTest.swift */,
 			);
 			path = vrm;
 			sourceTree = "<group>";
@@ -1853,6 +1860,7 @@
 				50A11DE11D59D7E000F4A068 /* AdURLProvider.swift in Sources */,
 				50A11DE21D59D7E000F4A068 /* Rethrow.swift in Sources */,
 				50A11DE51D59D7E000F4A068 /* Pipeline.swift in Sources */,
+				E26043FB220885B70034FC48 /* AdEngineResponseDetector.swift in Sources */,
 				E287B08D21F884A900FC49AA /* VRMSelectFinalResultController.swift in Sources */,
 				50A11DE61D59D7E000F4A068 /* VASTModel.swift in Sources */,
 				50A11DEB1D59D7E000F4A068 /* AdMetrics.swift in Sources */,
@@ -1879,6 +1887,7 @@
 				E2E4F7042089020E00182CDF /* VideoImpression.swift in Sources */,
 				DEBAA7BF1E154D4100DFC359 /* Future.swift in Sources */,
 				DEB112431E3277C1007E65BD /* Provider.swift in Sources */,
+				E26043FA220885B70034FC48 /* AdEngineResponseDetector.swift in Sources */,
 				DEB4DA6F1C9B10EB00D6FD08 /* OnMainThread.swift in Sources */,
 				5087484E1C80783700F2511A /* TrackingPixelsGenerator.swift in Sources */,
 				E287B0BA21FA097100FC49AA /* VPAIDAdCreativeController.swift in Sources */,
@@ -1995,6 +2004,7 @@
 				06D14E342203699000195483 /* AdCreativeTestData.swift in Sources */,
 				E2D649A8208A431D00152ADE /* VideoImpressionTest.swift in Sources */,
 				068B16522201E15C003ABD69 /* VPAIDAdCreativeControllerTest.swift in Sources */,
+				E26043FE220885C10034FC48 /* AdEngineResponseDetectorTest.swift in Sources */,
 				50C4602C1C80C0D8002AB8AB /* VideoPlayDetectorTests.swift in Sources */,
 				067209EC21B6BF440086CDBE /* BufferingDetectorTests.swift in Sources */,
 				DE1FB2971CE48FAC00B99941 /* VRMProviderTests.swift in Sources */,

--- a/sources/metrics/detectors/vrm/AdEngineResponseDetector.swift
+++ b/sources/metrics/detectors/vrm/AdEngineResponseDetector.swift
@@ -1,0 +1,85 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import Foundation
+import PlayerCore
+
+extension Detectors {
+    final class AdEngineResponseDetector {
+        
+        struct Result {
+            let metaInfo: Ad.Metrics.Info
+            let responseStatus: Ad.Metrics.ResponseStatus?
+            let responseTime: UInt?
+            let timeout: Int?
+            let fillType: Ad.Metrics.FillType?
+        }
+        
+        private var trackedItems = Set<VRMCore.Item>()
+        
+        func process(state: PlayerCore.State) -> [Result] {
+            let erroredItems = state.vrmRedirectError.erroredItems
+                .union(state.vrmFetchingError.erroredItems)
+                .union(state.vrmParsingError.erroredItems)
+            return process(timeoutBarrier: state.timeoutBarrier,
+                           completedItems: Set(state.vrmProcessingResult.processedAds.map{$0.item}),
+                           timeoutedTimes: state.vrmTimeoutError.erroredItems,
+                           otherErrors: erroredItems,
+                           responseTime: state.vrmItemResponseTime.timeRangeContainer,
+                           timeoutStatus: state.vrmProcessingTimeout)
+        }
+        
+        func process(timeoutBarrier: Double,
+                     completedItems: Set<VRMCore.Item>,
+                     timeoutedTimes: Set<VRMCore.Item>,
+                     otherErrors: Set<VRMCore.Item>,
+                     responseTime: [VRMCore.Item: VRMItemResponseTime.TimeRange],
+                     timeoutStatus: VRMProcessingTimeout) -> [Result] {
+            return completedItems
+                .union(timeoutedTimes)
+                .union(otherErrors)
+                .subtracting(trackedItems)
+                .map { item in
+                    trackedItems.insert(item)
+                    let responseStatus: Ad.Metrics.ResponseStatus = perform {
+                        if completedItems.contains(item) {
+                            return .yes
+                        } else if timeoutedTimes.contains(item) {
+                            return .timeout
+                        } else if otherErrors.contains(item) {
+                            return .no
+                        } else {
+                            fatalError("Imposible case. We are iterating over items from one of that set. Item should be present in one of them")
+                        }
+                    }
+                    
+                    let responseTime: UInt? = perform {
+                        guard let timeRange = responseTime[item],
+                            let finishAt = timeRange.finishAt else {
+                                return nil
+                        }
+                        return UInt(finishAt.timeIntervalSince(timeRange.startAt) * 1000)
+                    }
+                    
+                    let fillType: Ad.Metrics.FillType = perform {
+                        switch timeoutStatus {
+                        case .none: return .beforeSoft
+                        case .soft: return .afterSoft
+                        case .hard: return .afterHard
+                        }
+                    }
+                    
+                    let timeout: Int? = perform {
+                        guard responseStatus == .timeout else { return nil }
+                        return Int(timeoutBarrier * 1000)
+                    }
+                    
+                    return Result(metaInfo: .init(metaInfo: item.metaInfo),
+                                  responseStatus: responseStatus,
+                                  responseTime: responseTime,
+                                  timeout: timeout,
+                                  fillType: fillType)
+            }
+        }
+    }
+}

--- a/sources/metrics/detectors/vrm/AdEngineResponseDetectorTest.swift
+++ b/sources/metrics/detectors/vrm/AdEngineResponseDetectorTest.swift
@@ -1,0 +1,168 @@
+//  Copyright 2018, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import Quick
+import Nimble
+@testable import VerizonVideoPartnerSDK
+@testable import PlayerCore
+
+class AdEngineResponseDetectorSpec: QuickSpec {
+    
+    override func spec() {
+        let startAt = Date(timeIntervalSince1970: 0)
+        let finishAt = Date(timeIntervalSince1970: 2)
+        let timeout = 2.5
+        var metaInfo: VRMCore.Item.MetaInfo!
+        var item: VRMCore.Item!
+        var detector: Detectors.AdEngineResponseDetector!
+        var range: VRMItemResponseTime.TimeRange!
+        
+        var result: [Detectors.AdEngineResponseDetector.Result]!
+        
+        beforeEach {
+            detector = Detectors.AdEngineResponseDetector()
+            
+            metaInfo = VRMCore.Item.MetaInfo(engineType: "engineType",
+                                             ruleId: "ruleId",
+                                             ruleCompanyId: "ruleCompanyId",
+                                             vendor: "vendor",
+                                             name: "name",
+                                             cpm: "cpm")
+            item = VRMCore.Item(id: .init(),
+                                source: .vast(""),
+                                metaInfo: metaInfo)
+            
+            range = VRMItemResponseTime.TimeRange(startAt: startAt, finishAt: finishAt)
+            result = []
+        }
+        
+        it("Double detecting same item") {
+            result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [item],
+                                          timeoutedTimes: [],
+                                          otherErrors: [],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .none)
+                expect(result.count) == 1
+                
+            result = detector.process(timeoutBarrier: timeout,
+                                      completedItems: [item],
+                                          timeoutedTimes: [],
+                                          otherErrors: [],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .none)
+                expect(result.count) == 0
+        }
+        
+        context("On item finish processing") {
+            it("in complete") {
+                result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [item],
+                                          timeoutedTimes: [],
+                                          otherErrors: [],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .none)
+                expect(result.count) == 1
+            }
+            
+            it("in timeout") {
+                result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [],
+                                          timeoutedTimes: [item],
+                                          otherErrors: [],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .none)
+                expect(result.count) == 1
+            }
+            
+            it("in other errors") {
+                result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [],
+                                          timeoutedTimes: [],
+                                          otherErrors: [item],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .none)
+                expect(result.count) == 1
+            }
+        }
+        
+        context("Fill type") {
+            it("should be beforeSoft in case of none timeout"){
+                result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [item],
+                                          timeoutedTimes: [],
+                                          otherErrors: [],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .none)
+                expect(result.first?.fillType) == .beforeSoft
+            }
+            
+            it("should be afterSoft in case of soft timeout"){
+                result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [item],
+                                          timeoutedTimes: [],
+                                          otherErrors: [],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .soft)
+                expect(result.first?.fillType) == .afterSoft
+            }
+            
+            it("should be afterHard in case of hard timeout"){
+                result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [item],
+                                          timeoutedTimes: [],
+                                          otherErrors: [],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .hard)
+                expect(result.first?.fillType) == .afterHard
+            }
+        }
+        
+        context("Response status") {
+            it("should be yes in case of completed item"){
+                result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [item],
+                                          timeoutedTimes: [],
+                                          otherErrors: [],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .none)
+                expect(result.first?.responseStatus) == .yes
+                expect(result.first?.timeout).to(beNil())
+            }
+            
+            it("should be timeout in case of timeout item"){
+                result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [],
+                                          timeoutedTimes: [item],
+                                          otherErrors: [],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .hard)
+                expect(result.first?.responseStatus) == .timeout
+                expect(result.first?.timeout) == 2500
+            }
+            
+            it("should be no in case of errored item"){
+                result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [],
+                                          timeoutedTimes: [],
+                                          otherErrors: [item],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .hard)
+                expect(result.first?.responseStatus) == .no
+                expect(result.first?.timeout).to(beNil())
+            }
+        }
+        
+        context("Response time") {
+            it("should be diff between startAt and finishAt in milliseconds") {
+                result = detector.process(timeoutBarrier: timeout,
+                                          completedItems: [],
+                                          timeoutedTimes: [],
+                                          otherErrors: [item],
+                                          responseTime: [item: range],
+                                          timeoutStatus: .hard)
+                expect(result.first?.responseTime) == 2000
+            }
+        }
+    }
+}

--- a/sources/metrics/tracking pixels/TrackingPixelsConnector.swift
+++ b/sources/metrics/tracking pixels/TrackingPixelsConnector.swift
@@ -22,6 +22,7 @@ extension TrackingPixels {
         let vrmDetector = Detectors.VRMDetector()
         let adRequestDetector = Detectors.VRMRequestDetector()
         let adEngineRequestDetector = Detectors.AdEngineRequestDetector()
+        let adEngineResponseDetector = Detectors.AdEngineResponseDetector()
         
         let adVideoLoadingDetector = Detectors.VideoLoading()
         let adQuartileDetector = Detectors.Quartile()

--- a/sources/metrics/tracking pixels/TrackingPixelsConnector_Ad.swift
+++ b/sources/metrics/tracking pixels/TrackingPixelsConnector_Ad.swift
@@ -108,6 +108,18 @@ extension TrackingPixels.Connector {
                                      videoViewUID: state.playbackSession.id.uuidString)
         }
         
+        adEngineResponseDetector.process(state: state).forEach { result in
+            reporter.adEngineResponse(videoIndex: state.playlist.currentIndex,
+                                      info: result.metaInfo,
+                                      type: adType,
+                                      responseStatus: result.responseStatus,
+                                      responseTime: result.responseTime,
+                                      timeout: result.timeout,
+                                      fillType: result.fillType,
+                                      transactionId: transactionId,
+                                      videoViewUID: state.playbackSession.id.uuidString)
+        }
+        
         vrmDetector.process(state: state.adVRMManager).forEach { result in
             switch result {
             case .completeRequest(let complete):


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Added ad-engine-response detector.
Moved all processing of parameters inside the detector.
I've used `Quick/Nimble` for testing because there were a lot of small check which I wanted to describe in a better way.

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
