### PR TITLE
Added internal id for AdCreative, Fix Ad Request Detector

### DIFF
--- a/sources/advertisements/creative controllers/AdCreativeTestData.swift
+++ b/sources/advertisements/creative controllers/AdCreativeTestData.swift
@@ -4,9 +4,10 @@
 import Foundation
 import PlayerCore
 
-func getMP4Creative(width: Int, height: Int) -> AdCreative.MP4 {
+func getMP4Creative(internalID: UUID = UUID(), width: Int, height: Int) -> AdCreative.MP4 {
     let testURL = URL(string: "https://")!
-    return AdCreative.MP4(url: testURL,
+    return AdCreative.MP4(internalID: internalID,
+                          url: testURL,
                           clickthrough: testURL,
                           pixels: AdPixels(),
                           id: "",
@@ -16,9 +17,10 @@ func getMP4Creative(width: Int, height: Int) -> AdCreative.MP4 {
                           maintainAspectRatio: true)
 }
 
-func getVPAIDCreative() -> AdCreative.VPAID {
+func getVPAIDCreative(internalID: UUID = UUID()) -> AdCreative.VPAID {
     let testURL = URL(string: "https://")!
-    return AdCreative.VPAID(url: testURL,
+    return AdCreative.VPAID(internalID: internalID,
+                            url: testURL,
                             adParameters: "",
                             clickthrough: testURL,
                             pixels: AdPixels(),

--- a/sources/advertisements/creative controllers/MP4AdCreativeControllerTest.swift
+++ b/sources/advertisements/creative controllers/MP4AdCreativeControllerTest.swift
@@ -22,18 +22,19 @@ class MP4AdCreativeControllerTest: XCTestCase {
     }
     
     func testSingleMP4Creative() {
+        let internalID = UUID()
         recorder.record {
-            sut.process(adCreative: .mp4([getMP4Creative(width: 320, height: 240)]),
+            sut.process(adCreative: .mp4([getMP4Creative(internalID: internalID, width: 320, height: 240)]),
                         viewport: CGSize(width: 480, height: 320),
                         id: id)
-            sut.process(adCreative: .mp4([getMP4Creative(width: 320, height: 240)]),
+            sut.process(adCreative: .mp4([getMP4Creative(internalID: internalID, width: 320, height: 240)]),
                         viewport: CGSize(width: 480, height: 320),
                         id: UUID())
             
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.ShowMP4Ad(creative: getMP4Creative(width: 320, height: 240), id: id))
+            sut.dispatch(PlayerCore.ShowMP4Ad(creative: getMP4Creative(internalID: internalID, width: 320, height: 240), id: id))
         }
     }
     
@@ -47,36 +48,39 @@ class MP4AdCreativeControllerTest: XCTestCase {
     }
     
     func testDispatchAppropriateAdBySize() {
+        let selected = getMP4Creative(width: 640, height: 360)
         recorder.record {
             sut.process(adCreative: .mp4([getMP4Creative(width: 640, height: 480),
-                                          getMP4Creative(width: 640, height: 360),
+                                          selected,
                                           getMP4Creative(width: 320, height: 180)]),
                         viewport: CGSize(width: 520, height: 380),
                         id: id)
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.ShowMP4Ad(creative: getMP4Creative(width: 640, height: 360), id: id))
+            sut.dispatch(PlayerCore.ShowMP4Ad(creative: selected, id: id))
         }
     }
     
     func testDispatchTheSmallestAdBySize() {
+        let selected = getMP4Creative(width: 320, height: 180)
         recorder.record {
             sut.process(adCreative: .mp4([getMP4Creative(width: 640, height: 480),
                                           getMP4Creative(width: 640, height: 360),
-                                          getMP4Creative(width: 320, height: 180)]),
+                                          selected]),
                         viewport: CGSize(width: 240, height: 160),
                         id: id)
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.ShowMP4Ad(creative: getMP4Creative(width: 320, height: 180), id: id))
+            sut.dispatch(PlayerCore.ShowMP4Ad(creative: selected, id: id))
         }
     }
     
     func testDispatchTheBiggestAdBySize() {
+        let selected = getMP4Creative(width: 640, height: 480)
         recorder.record {
-            sut.process(adCreative: .mp4([getMP4Creative(width: 640, height: 480),
+            sut.process(adCreative: .mp4([selected,
                                           getMP4Creative(width: 640, height: 360),
                                           getMP4Creative(width: 320, height: 180)]),
                         viewport: CGSize(width: 896, height: 414),
@@ -84,7 +88,7 @@ class MP4AdCreativeControllerTest: XCTestCase {
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.ShowMP4Ad(creative: getMP4Creative(width: 640, height: 480), id: id))
+            sut.dispatch(PlayerCore.ShowMP4Ad(creative: selected, id: id))
         }
     }
 }

--- a/sources/advertisements/creative controllers/VPAIDAdCreativeControllerTest.swift
+++ b/sources/advertisements/creative controllers/VPAIDAdCreativeControllerTest.swift
@@ -21,16 +21,15 @@ class VPAIDAdCreativeControllerTest: XCTestCase {
     }
     
     func testSingleMP4Creative() {
+        let selected = getVPAIDCreative()
         recorder.record {
-            sut.process(adCreative: .vpaid([getVPAIDCreative()]),
-                        id: id)
-            sut.process(adCreative: .vpaid([getVPAIDCreative()]),
-                        id: UUID())
+            sut.process(adCreative: .vpaid([selected]),id: id)
+            sut.process(adCreative: .vpaid([selected]),id: UUID())
             
         }
         
         recorder.verify {
-            sut.dispatch(PlayerCore.ShowVPAIDAd(creative: getVPAIDCreative(), id: id))
+            sut.dispatch(PlayerCore.ShowVPAIDAd(creative: selected, id: id))
         }
     }
     

--- a/sources/metrics/detectors/ad max show time/AdMaxShowTimeDetector.swift
+++ b/sources/metrics/detectors/ad max show time/AdMaxShowTimeDetector.swift
@@ -10,7 +10,8 @@ extension Detectors {
         private var isReported = true
         
         func process(state: PlayerCore.State) -> Bool {
-            return process(adKill: state.adKill, sessionId: state.adVRMManager.request.id)
+            return process(adKill: state.adKill,
+                           sessionId: state.adVRMManager.request.id ?? state.vrmRequestStatus.request?.id)
         }
         
         func process(adKill: AdKill, sessionId: UUID?) -> Bool {

--- a/sources/metrics/detectors/vrm/VRMRequestDetector.swift
+++ b/sources/metrics/detectors/vrm/VRMRequestDetector.swift
@@ -10,15 +10,31 @@ extension Detectors {
             let transactionId: String?
         }
         
+        enum ResponseStatus {
+            case noResponse
+            case response(transactionID: String?)
+            
+            init(response: VRMResponse?) {
+                switch response {
+                case .none:
+                    self = .noResponse
+                case .some(let value):
+                    self = .response(transactionID: value.transactionId)
+                }
+            }
+        }
+        
         private var trackedRequests = Set<UUID>()
         
         func process(with state: PlayerCore.State) -> Result? {
             return process(with: state.vrmRequestStatus.request?.id,
-                           transactionId: state.vrmResponse?.transactionId)
+                           vrmResponseStatus: ResponseStatus(response: state.vrmResponse))
         }
         
-        func process(with requestId: UUID?, transactionId: String?) -> Result? {
+        func process(with requestId: UUID?,
+                     vrmResponseStatus: ResponseStatus) -> Result? {
             guard let requestId = requestId,
+                case let .response(transactionId) = vrmResponseStatus,
                 trackedRequests.contains(requestId) == false else { return nil }
             
             trackedRequests.insert(requestId)

--- a/sources/metrics/detectors/vrm/VRMRequestDetectorTest.swift
+++ b/sources/metrics/detectors/vrm/VRMRequestDetectorTest.swift
@@ -6,25 +6,33 @@ import XCTest
 @testable import PlayerCore
 
 class VRMRequestDetectorTest: XCTestCase {
-
+    
     func testDetectSameRequest() {
         let uuid = UUID()
         let sut = Detectors.VRMRequestDetector()
         
-        var result = sut.process(with: uuid, transactionId: "id")
+        var result = sut.process(with: uuid, vrmResponseStatus: .response(transactionID: "id"))
         XCTAssertEqual(result?.transactionId, "id")
         
-        result = sut.process(with: uuid, transactionId: "id")
+        result = sut.process(with: uuid, vrmResponseStatus: .response(transactionID: "id"))
         XCTAssertNil(result)
     }
 
     func testDetectDiffRequests() {
         let sut = Detectors.VRMRequestDetector()
         
-        var result = sut.process(with: UUID(), transactionId: "id1")
-        XCTAssertEqual(result?.transactionId, "id1")
+        var result = sut.process(with: UUID(), vrmResponseStatus: .response(transactionID: "id"))
+        XCTAssertEqual(result?.transactionId, "id")
         
-        result = sut.process(with: UUID(), transactionId: "id2")
-        XCTAssertEqual(result?.transactionId, "id2")
+        result = sut.process(with: UUID(), vrmResponseStatus: .response(transactionID: "id"))
+        XCTAssertEqual(result?.transactionId, "id")
+    }
+    
+    func testNoDetectionIfResponseNil() {
+        let sut = Detectors.VRMRequestDetector()
+        
+        let result = sut.process(with: UUID(), vrmResponseStatus: .noResponse)
+        
+        XCTAssertNil(result)
     }
 }

--- a/sources/metrics/tracking pixels/TrackingPixelsConnector_Ad.swift
+++ b/sources/metrics/tracking pixels/TrackingPixelsConnector_Ad.swift
@@ -563,7 +563,7 @@ extension TrackingPixels.Connector {
             }
             
             /* Ad Error Detector */ do {
-                adErrorDetector.process(id: state.adVRMManager.request.id,
+                adErrorDetector.process(id: sessionID ,
                                         error: perform {
                                             guard case .errored(let error) = state.playbackStatus.ad else { return nil }
                                             return error


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
---
### AdCreative
#### Issue
There was an issue with array of videos. Second video wasn't played, because it has the same `AdCreative` as first vide in playlist. That's why `MP4AdCreativeController` filter second videos `AdCreative` and didn't dispatch `ShowAd` action.
#### Fix
I've added unique internal id for each `AdCreative`, to make they Equatable even if they have same other properties.

---
### Ad Request
#### Issue
No need to fire `ad-request` in case if we didn't get vrm response
#### Fix
Added check for vrm response.



@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
