### PR TITLE
Renamed skipAd action to dropAd

### DIFF
--- a/sources/VVPSDK.swift
+++ b/sources/VVPSDK.swift
@@ -386,7 +386,7 @@ public struct VVPSDK {
                                       dispatcher: dispatcher)
             
             weak var player = player
-            adManager.actions.skipPreroll = { player?.skipAd(id: $0) }
+            adManager.actions.dropPreroll = { player?.dropAd(id: $0) }
             adManager.actions.startPreroll = { player?.playAd(model: $0) }
             let _ = player?.addObserver { playerProps in
                 guard let item = playerProps.playbackItem else { return }

--- a/sources/advertisements/AdManagerPresenter.swift
+++ b/sources/advertisements/AdManagerPresenter.swift
@@ -4,7 +4,7 @@ import Foundation
 import PlayerCore
 
 struct AdManagerActions<Result> {
-    var skipPreroll = nop() as Action<UUID>
+    var dropPreroll = nop() as Action<UUID>
     var startPreroll = nop() as Action<Result>
 }
 
@@ -65,7 +65,7 @@ final class AdManager<Result> {
                 if let model = result {
                     self.actions.startPreroll(model)
                 } else {
-                    self.actions.skipPreroll(id)
+                    self.actions.dropPreroll(id)
                 }
             }
         }

--- a/sources/advertisements/AdManagerPresenterTests.swift
+++ b/sources/advertisements/AdManagerPresenterTests.swift
@@ -34,7 +34,7 @@ class AdManagerPresenterTests: QuickSpec {
                                 XCTFail("Expecting AdRequest with advertisement ID!")
                             }
                     })
-                    adManager?.actions.skipPreroll = recorder.hook("skip preroll")
+                    adManager?.actions.dropPreroll = recorder.hook("drop preroll")
                     adManager?.actions.startPreroll = recorder.hook("start preroll")
                 }
             }
@@ -74,7 +74,7 @@ class AdManagerPresenterTests: QuickSpec {
                 recorder.verify {}
             }
             
-            it("should skip preroll") {
+            it("should drop preroll") {
                 recorder.record {
                     adManager.props.preroll.count = 1
                     adManager.props.preroll.number = 0
@@ -92,7 +92,7 @@ class AdManagerPresenterTests: QuickSpec {
                 }
                 
                 recorder.verify {
-                    adManager.actions.skipPreroll(adID!)
+                    adManager.actions.dropPreroll(adID!)
                 }
                 
                 recorder.record {

--- a/sources/advertisements/MidrollDetector.swift
+++ b/sources/advertisements/MidrollDetector.swift
@@ -96,7 +96,7 @@ class MidrollDetector {
             state.lastPrefetchedMidroll = midroll
             state.prefetchedModel = nil
             guard let model = model else {
-                dispatcher(PlayerCore.skipAd(id: midroll.id))
+                dispatcher(PlayerCore.dropAd(id: midroll.id))
                 return
             }
             dispatcher(PlayerCore.playAd(model: model,

--- a/sources/advertisements/MidrollDetectorTests.swift
+++ b/sources/advertisements/MidrollDetectorTests.swift
@@ -40,7 +40,7 @@ class MidrollDetectorTests: QuickSpec {
                             guard let targetShowAdCreative = targetShowAdCreatives.first,
                                 let recordShowAdCreative = recordShowAdCreatives.first else { return false }
                             return targetShowAdCreative.url == recordShowAdCreative.url
-                        case (let targetSkipAd as SkipAd, let recordSkipAd as SkipAd):
+                        case (let targetSkipAd as DropAd, let recordSkipAd as DropAd):
                             return targetSkipAd.id == recordSkipAd.id
                         default: return false
                         }
@@ -185,7 +185,7 @@ class MidrollDetectorTests: QuickSpec {
                     
                     recorder.verify {
                         guard let midrollId = midrollDetector.state.lastPrefetchedMidroll?.id else { return XCTFail("Got nil midroll id") }
-                        midrollDetector.dispatcher(PlayerCore.skipAd(id: midrollId))
+                        midrollDetector.dispatcher(PlayerCore.dropAd(id: midrollId))
                     }
                 }
                 

--- a/sources/player/PlayerInterface.swift
+++ b/sources/player/PlayerInterface.swift
@@ -223,8 +223,8 @@ extension Player {
         dispatch(action: PlayerCore.adPlaybackIsFailed(error: error))
     }
     
-    func skipAd(id: UUID) {
-        dispatch(action: PlayerCore.skipAd(id: id))
+    func dropAd(id: UUID) {
+        dispatch(action: PlayerCore.dropAd(id: id))
     }
 }
 


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- `skipAd` action replaced with `dropAd` action.

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.