### PR TITLE
Added open measurement skip action and added check for skip in props

### DIFF
--- a/sources/metrics/open measurement/OpenMeasurementContext.swift
+++ b/sources/metrics/open measurement/OpenMeasurementContext.swift
@@ -88,7 +88,8 @@ enum OpenMeasurement {
             resume: omidVideoEvents.resume,
             pause: omidVideoEvents.pause,
             click: { omidVideoEvents.adUserInteraction(withType: .click) },
-            volumeChange: omidVideoEvents.volumeChange)
+            volumeChange: omidVideoEvents.volumeChange,
+            skip: omidVideoEvents.skipped)
         
         return Output(adSession: adSession, adEvents: adEvents, videoEvents: videoEvents)
     }

--- a/sources/metrics/tracking pixels/TrackingPixelsConnector_Ad.swift
+++ b/sources/metrics/tracking pixels/TrackingPixelsConnector_Ad.swift
@@ -301,6 +301,7 @@ extension TrackingPixels.Connector {
                 report { payload in
                     reporter.sendBeacon(urls: payload.pixels.skip)
                     engineFlow(stage: .skipped, payload: payload)
+                    openMeasurementVideoEvents?.skip()
                 }
             }
         }

--- a/sources/player/PlayerProperties_Init.swift
+++ b/sources/player/PlayerProperties_Init.swift
@@ -92,9 +92,11 @@ extension Player.Properties {
             let currentTime = Int(state.currentTime.ad.seconds.rounded())
             switch skipOffset {
             case .time(let value):
+                guard value < Int(duration) else { return nil }
                 return value - currentTime
             case .percentage(let value):
                 let offset = Int(duration.rounded() / 100 * Double(value))
+                guard offset < Int(duration) else { return nil }
                 return offset - currentTime
             default: return nil
             }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Updated `PlayerCore` with `skip` action for open measurement;
- Added check in skip offset logic if the offset is bigger than the duration.

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
