### PR TITLE
Added adProgress in merge methods of wrapper

### DIFF
--- a/sources/advertisements/VASTModel.swift
+++ b/sources/advertisements/VASTModel.swift
@@ -19,7 +19,9 @@ enum VASTModel {
 }
 
 extension PlayerCore.Ad.VASTModel {
-    func merge(with pixels: AdPixels, and verifications: [PlayerCore.Ad.VASTModel.AdVerification]) -> PlayerCore.Ad.VASTModel {
+    func merge(pixels: AdPixels,
+               verifications: [PlayerCore.Ad.VASTModel.AdVerification],
+               adProgress: [PlayerCore.Ad.VASTModel.AdProgress]) -> PlayerCore.Ad.VASTModel {
         return PlayerCore.Ad.VASTModel(
             adVerifications: self.adVerifications + verifications,
             mp4MediaFiles: mp4MediaFiles,

--- a/sources/advertisements/VASTParser.swift
+++ b/sources/advertisements/VASTParser.swift
@@ -408,7 +408,7 @@ enum VASTParser {
                                             guard let offset = attr["offset"] else { break }
                                             guard let progressOffset = VASTParser.getOffset(from: offset) else { break }
                                             adProgress.append(.init(url: url,
-                                                                                  offset: progressOffset))
+                                                                    offset: progressOffset))
                                         default: break }
                                     }
                                     

--- a/sources/advertisements/VASTWrapperProcessor.swift
+++ b/sources/advertisements/VASTWrapperProcessor.swift
@@ -38,7 +38,7 @@ struct VASTWrapperProcessor {
                 case .timeout: return Future(value: .timeoutError)
                 case .parsingError: return Future(value: .parsingError)
                 case .model(.inline(let model)):
-                    return Future(value: .model(model.merge(with: wrapper1.pixels, and: wrapper1.adVerifications)))
+                    return Future(value: .model(model.merge(pixels: wrapper1.pixels, verifications: wrapper1.adVerifications, adProgress: wrapper1.progress)))
                     
                 case .model(.wrapper(let wrapper2)):
                     return self.innerFetch(wrapper2.tagURL).then { result in
@@ -48,8 +48,8 @@ struct VASTWrapperProcessor {
                         case .parsingError: return Future(value: .parsingError)
                         case .model(.inline(let model)):
                             return Future(value: .model(
-                                model.merge(with: wrapper1.pixels, and: wrapper1.adVerifications)
-                                    .merge(with: wrapper2.pixels, and: wrapper2.adVerifications))
+                                model.merge(pixels: wrapper1.pixels, verifications: wrapper1.adVerifications, adProgress: wrapper1.progress)
+                                    .merge(pixels: wrapper2.pixels, verifications: wrapper2.adVerifications, adProgress: wrapper2.progress))
                             )
 
                         case .model(.wrapper): return Future(value: .tooManyIndirections)

--- a/sources/advertisements/VRM New Core/Controllers/ParseVRMItemController.swift
+++ b/sources/advertisements/VRM New Core/Controllers/ParseVRMItemController.swift
@@ -9,7 +9,8 @@ func vastMapper(vastModel: VASTModel) -> VRMCore.VASTModel {
     case .wrapper(let wrapper):
         let vrmCoreWrapper = VRMCore.VASTModel.WrapperModel(tagURL: wrapper.tagURL,
                                                             adVerifications: wrapper.adVerifications,
-                                                            pixels: wrapper.pixels)
+                                                            pixels: wrapper.pixels,
+                                                            adProgress: wrapper.progress)
         return VRMCore.VASTModel.wrapper(vrmCoreWrapper)
     case .inline(let model):
         return VRMCore.VASTModel.inline(model)

--- a/sources/advertisements/VRM New Core/Controllers/VRMProcessingControllerTest.swift
+++ b/sources/advertisements/VRM New Core/Controllers/VRMProcessingControllerTest.swift
@@ -50,7 +50,8 @@ class VRMProcessingControllerTest: XCTestCase {
                                                                 maintainAspectRatio: true)
         wrapper = VRMCore.VASTModel.wrapper(.init(tagURL: wrapperUrl,
                                                   adVerifications: [],
-                                                  pixels: .init()))
+                                                  pixels: .init(),
+                                                  adProgress: []))
         adModel = .init(adVerifications: [],
                         mp4MediaFiles: [mp4MEdiaFile],
                         vpaidMediaFiles: [vpaidMediaFile],


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Fixed merge methods by including `adProgress` tracking from multiple wrapper and inline models.

## Tests
| Before | 
| - |
| ![screen shot 2019-02-21 at 18 34 24](https://user-images.githubusercontent.com/31652265/53187864-b377ef80-360c-11e9-9599-846bfb900ebd.png) |

| After |
| - |
| ![screen shot 2019-02-21 at 18 34 18](https://user-images.githubusercontent.com/31652265/53187868-b541b300-360c-11e9-9a49-75839b21b837.png) |


@VerizonAdPlatforms/video-partner-sdk-developers: Please review.