### PR TITLE
Fixed parsing for multiple creatives in VAST

### DIFF
--- a/VerizonVideoPartnerSDK.xcodeproj/project.pbxproj
+++ b/VerizonVideoPartnerSDK.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		061CFFFC211C7263002B5BE9 /* MuteDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061CFFFB211C7263002B5BE9 /* MuteDetectorTests.swift */; };
 		061CFFFE211C7272002B5BE9 /* MuteDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061CFFFD211C7272002B5BE9 /* MuteDetector.swift */; };
 		061CFFFF211C7272002B5BE9 /* MuteDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061CFFFD211C7272002B5BE9 /* MuteDetector.swift */; };
+		061EB355222573C700DF149C /* VASTMultipleCreatives.xml in Resources */ = {isa = PBXBuildFile; fileRef = 061EB3522225731F00DF149C /* VASTMultipleCreatives.xml */; };
 		062E9B3E20F5097C00AF1D54 /* PlayerViewController_Clickthrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062E9B3D20F5097C00AF1D54 /* PlayerViewController_Clickthrough.swift */; };
 		063988A72100C95000FE8475 /* VPAIDMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063988A62100C95000FE8475 /* VPAIDMessageHandler.swift */; };
 		063C8354221C568D0052C1DC /* AdEngineResponseDetectorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26043F9220885B60034FC48 /* AdEngineResponseDetectorSpec.swift */; };
@@ -454,6 +455,7 @@
 		061AFD6421F256CA0024BAC5 /* ContentPlaybackCycleDetectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ContentPlaybackCycleDetectorTests.swift; path = "playback cycle/ContentPlaybackCycleDetectorTests.swift"; sourceTree = "<group>"; };
 		061CFFFB211C7263002B5BE9 /* MuteDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuteDetectorTests.swift; sourceTree = "<group>"; };
 		061CFFFD211C7272002B5BE9 /* MuteDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuteDetector.swift; sourceTree = "<group>"; };
+		061EB3522225731F00DF149C /* VASTMultipleCreatives.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = VASTMultipleCreatives.xml; sourceTree = "<group>"; };
 		062E9B3D20F5097C00AF1D54 /* PlayerViewController_Clickthrough.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlayerViewController_Clickthrough.swift; path = "sources/custom controls/PlayerViewController_Clickthrough.swift"; sourceTree = "<group>"; };
 		063988A62100C95000FE8475 /* VPAIDMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPAIDMessageHandler.swift; sourceTree = "<group>"; };
 		06419E1720EF7433007FE2F0 /* WebviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebviewViewController.swift; sourceTree = "<group>"; };
@@ -1083,6 +1085,7 @@
 				DEF02B581D22970A001F64EE /* VAST1.xml */,
 				DE1685E41CE768E600492A90 /* VASTExampleCDATA.xml */,
 				DE1FD9CE1CE7737900C0B7BC /* VASTMissedCorrectType.xml */,
+				061EB3522225731F00DF149C /* VASTMultipleCreatives.xml */,
 				067209D921B6BE710086CDBE /* VASTVerificationInExtension.xml */,
 				06BF541620A062E300B98A6D /* VASTVpaid.xml */,
 				B418F5461ECB267B00C9131D /* VASTWrapper.xml */,
@@ -1672,6 +1675,7 @@
 				50A039591F30D54C00DDAE4B /* UnrecognizedTrackingFixture.json in Resources */,
 				DEF02B5A1D229768001F64EE /* VAST1.xml in Resources */,
 				DE1FD9CF1CE7737900C0B7BC /* VASTMissedCorrectType.xml in Resources */,
+				061EB355222573C700DF149C /* VASTMultipleCreatives.xml in Resources */,
 				5087484F1C80787700F2511A /* empty playlist.json in Resources */,
 				06BF541F20A078FE00B98A6D /* VASTVpaid.xml in Resources */,
 				067209DB21B6BE710086CDBE /* VASTVerificationInExtension.xml in Resources */,

--- a/sources/advertisements/VASTMultipleCreatives.xml
+++ b/sources/advertisements/VASTMultipleCreatives.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VAST version="3.0">
+    <Ad id="1">
+    <InLine>
+        <AdSystem version="4.11.1-55">LiveRail</AdSystem>
+        <AdTitle><![CDATA[LiveRail creative 1]]></AdTitle>
+        <Description><![CDATA[]]></Description>
+        <Error><![CDATA[http://localhost:3000/0/beacons/vast/error.gif]]></Error>
+        <Impression><![CDATA[http://localhost:3000/0/beacons/vast/impression.gif]]></Impression>
+        <Creatives>
+            <Creative sequence="1" id="7969">
+                <Linear skipoffset="32%">
+                    <Duration>00:00:11</Duration>
+                    
+                    <TrackingEvents>
+                        <Tracking event="skip"><![CDATA[http://localhost:3000/1/beacons/vast/skip.gif]]></Tracking>
+                        <Tracking event="firstQuartile"><![CDATA[http://localhost:3000/1/beacons/vast/firstQuartile.gif]]></Tracking>
+                        <Tracking event="midpoint"><![CDATA[http://localhost:3000/1/beacons/vast/midpoint.gif]]></Tracking>
+                        <Tracking event="thirdQuartile"><![CDATA[http://localhost:3000/1/beacons/vast/thirdQuartile.gif]]></Tracking>
+                        <Tracking event="complete"><![CDATA[http://localhost:3000/1/beacons/vast/complete.gif]]></Tracking>
+                        <Tracking event="mute"><![CDATA[http://localhost:3000/1/beacons/vast/mute.gif]]></Tracking>
+                        <Tracking event="unmute"><![CDATA[http://localhost:3000/1/beacons/vast/unmute.gif]]></Tracking>
+                        <Tracking event="pause"><![CDATA[http://localhost:3000/1/beacons/vast/pause.gif]]></Tracking>
+                        <Tracking event="resume"><![CDATA[http://localhost:3000/1/beacons/vast/resume.gif]]></Tracking>
+                        <Tracking event="fullscreen"><![CDATA[http://localhost:3000/1/beacons/vast/fullscreen.gif]]></Tracking>
+                        <Tracking event="close"><![CDATA[http://localhost:3000/1/beacons/vast/close.gif]]></Tracking>
+                        <Tracking event="acceptInvitation"><![CDATA[http://localhost:3000/1/beacons/vast/acceptInvitation.gif]]></Tracking>
+                        <Tracking event="collapse"><![CDATA[http://localhost:3000/1/beacons/vast/collapse.gif]]></Tracking>
+                        <Tracking event="progress" offset="10%">
+                            <![CDATA[http://localhost:3000/1/beacons/vast/progress.gif]]></Tracking>
+                    </TrackingEvents>
+                    
+                    <VideoClicks>
+                        <ClickTracking><![CDATA[http://localhost:3000/1/beacons/vast/click.gif]]></ClickTracking>
+                    </VideoClicks>
+                    
+                    <MediaFiles>
+                        <MediaFile delivery="progressive" bitrate="400" width="320" height="180" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/lo.mp4]]></MediaFile>
+                        <MediaFile delivery="progressive" bitrate="600" width="640" height="480" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/me.mp4]]></MediaFile>
+                        <MediaFile delivery="progressive" bitrate="1024" width="640" height="480" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/hi.mp4]]></MediaFile>
+                    </MediaFiles>
+                </Linear>
+            </Creative>
+            <Creative sequence="2" id="7970">
+                <Linear skipoffset="00:00:05">
+                    <Duration>00:00:11</Duration>
+                    
+                    <TrackingEvents>
+                        <Tracking event="skip"><![CDATA[http://localhost:3000/2/beacons/vast/skip.gif]]></Tracking>
+                        <Tracking event="firstQuartile"><![CDATA[http://localhost:3000/2/beacons/vast/firstQuartile.gif]]></Tracking>
+                        <Tracking event="midpoint"><![CDATA[http://localhost:3000/2/beacons/vast/midpoint.gif]]></Tracking>
+                        <Tracking event="thirdQuartile"><![CDATA[http://localhost:3000/2/beacons/vast/thirdQuartile.gif]]></Tracking>
+                        <Tracking event="complete"><![CDATA[http://localhost:3000/2/beacons/vast/complete.gif]]></Tracking>
+                        <Tracking event="mute"><![CDATA[http://localhost:3000/2/beacons/vast/mute.gif]]></Tracking>
+                        <Tracking event="unmute"><![CDATA[http://localhost:3000/2/beacons/vast/unmute.gif]]></Tracking>
+                        <Tracking event="pause"><![CDATA[http://localhost:3000/2/beacons/vast/pause.gif]]></Tracking>
+                        <Tracking event="resume"><![CDATA[http://localhost:3000/2/beacons/vast/resume.gif]]></Tracking>
+                        <Tracking event="fullscreen"><![CDATA[http://localhost:3000/2/beacons/vast/fullscreen.gif]]></Tracking>
+                        <Tracking event="close"><![CDATA[http://localhost:3000/2/beacons/vast/close.gif]]></Tracking>
+                        <Tracking event="acceptInvitation"><![CDATA[http://localhost:3000/2/beacons/vast/acceptInvitation.gif]]></Tracking>
+                        <Tracking event="collapse"><![CDATA[http://localhost:3000/2/beacons/vast/collapse.gif]]></Tracking>
+                        <Tracking event="progress" offset="00:00:03">
+                            <![CDATA[http://localhost:3000/2/beacons/vast/progress.gif]]></Tracking>
+                    </TrackingEvents>
+                    
+                    <VideoClicks>
+                        <ClickTracking><![CDATA[http://localhost:3000/2/beacons/vast/click.gif]]></ClickTracking>
+                    </VideoClicks>
+                    
+                    <MediaFiles>
+                        <MediaFile delivery="progressive" bitrate="400" width="320" height="180" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/lo.mp4]]></MediaFile>
+                        <MediaFile delivery="progressive" bitrate="600" width="640" height="480" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/me.mp4]]></MediaFile>
+                        <MediaFile delivery="progressive" bitrate="1024" width="640" height="480" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/hi.mp4]]></MediaFile>
+                    </MediaFiles>
+                </Linear>
+            </Creative>
+        </Creatives>
+        <Extensions>
+        </Extensions>
+    </InLine>
+</Ad>
+
+
+<Ad id="2">
+    <InLine>
+        <AdSystem version="4.11.1-55">LiveRail</AdSystem>
+        <AdTitle><![CDATA[LiveRail creative 2]]></AdTitle>
+        <Description><![CDATA[]]></Description>
+        <Error><![CDATA[http://localhost:3000/0/beacons/vast/error.gif]]></Error>
+        <Impression><![CDATA[http://localhost:3000/0/beacons/vast/impression.gif]]></Impression>
+        <Creatives>
+            <Creative sequence="1" id="7969">
+                <Linear skipoffset="32%">
+                    <Duration>00:00:11</Duration>
+                    
+                    <TrackingEvents>
+                        <Tracking event="skip"><![CDATA[http://localhost:3000/1/beacons/vast/skip.gif]]></Tracking>
+                        <Tracking event="firstQuartile"><![CDATA[http://localhost:3000/1/beacons/vast/firstQuartile.gif]]></Tracking>
+                        <Tracking event="midpoint"><![CDATA[http://localhost:3000/1/beacons/vast/midpoint.gif]]></Tracking>
+                        <Tracking event="thirdQuartile"><![CDATA[http://localhost:3000/1/beacons/vast/thirdQuartile.gif]]></Tracking>
+                        <Tracking event="complete"><![CDATA[http://localhost:3000/1/beacons/vast/complete.gif]]></Tracking>
+                        <Tracking event="mute"><![CDATA[http://localhost:3000/1/beacons/vast/mute.gif]]></Tracking>
+                        <Tracking event="unmute"><![CDATA[http://localhost:3000/1/beacons/vast/unmute.gif]]></Tracking>
+                        <Tracking event="pause"><![CDATA[http://localhost:3000/1/beacons/vast/pause.gif]]></Tracking>
+                        <Tracking event="resume"><![CDATA[http://localhost:3000/1/beacons/vast/resume.gif]]></Tracking>
+                        <Tracking event="fullscreen"><![CDATA[http://localhost:3000/1/beacons/vast/fullscreen.gif]]></Tracking>
+                        <Tracking event="close"><![CDATA[http://localhost:3000/1/beacons/vast/close.gif]]></Tracking>
+                        <Tracking event="acceptInvitation"><![CDATA[http://localhost:3000/1/beacons/vast/acceptInvitation.gif]]></Tracking>
+                        <Tracking event="collapse"><![CDATA[http://localhost:3000/1/beacons/vast/collapse.gif]]></Tracking>
+                        <Tracking event="progress" offset="10%">
+                            <![CDATA[http://localhost:3000/1/beacons/vast/progress.gif]]></Tracking>
+                    </TrackingEvents>
+                    
+                    <VideoClicks>
+                        <ClickTracking><![CDATA[http://localhost:3000/1/beacons/vast/click.gif]]></ClickTracking>
+                    </VideoClicks>
+                    
+                    <MediaFiles>
+                        <MediaFile delivery="progressive" bitrate="400" width="320" height="180" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/lo.mp4]]></MediaFile>
+                        <MediaFile delivery="progressive" bitrate="600" width="640" height="480" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/me.mp4]]></MediaFile>
+                        <MediaFile delivery="progressive" bitrate="1024" width="640" height="480" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/hi.mp4]]></MediaFile>
+                    </MediaFiles>
+                </Linear>
+            </Creative>
+            <Creative sequence="2" id="7970">
+                <Linear skipoffset="00:00:05">
+                    <Duration>00:00:11</Duration>
+                    
+                    <TrackingEvents>
+                        <Tracking event="skip"><![CDATA[http://localhost:3000/2/beacons/vast/skip.gif]]></Tracking>
+                        <Tracking event="firstQuartile"><![CDATA[http://localhost:3000/2/beacons/vast/firstQuartile.gif]]></Tracking>
+                        <Tracking event="midpoint"><![CDATA[http://localhost:3000/2/beacons/vast/midpoint.gif]]></Tracking>
+                        <Tracking event="thirdQuartile"><![CDATA[http://localhost:3000/2/beacons/vast/thirdQuartile.gif]]></Tracking>
+                        <Tracking event="complete"><![CDATA[http://localhost:3000/2/beacons/vast/complete.gif]]></Tracking>
+                        <Tracking event="mute"><![CDATA[http://localhost:3000/2/beacons/vast/mute.gif]]></Tracking>
+                        <Tracking event="unmute"><![CDATA[http://localhost:3000/2/beacons/vast/unmute.gif]]></Tracking>
+                        <Tracking event="pause"><![CDATA[http://localhost:3000/2/beacons/vast/pause.gif]]></Tracking>
+                        <Tracking event="resume"><![CDATA[http://localhost:3000/2/beacons/vast/resume.gif]]></Tracking>
+                        <Tracking event="fullscreen"><![CDATA[http://localhost:3000/2/beacons/vast/fullscreen.gif]]></Tracking>
+                        <Tracking event="close"><![CDATA[http://localhost:3000/2/beacons/vast/close.gif]]></Tracking>
+                        <Tracking event="acceptInvitation"><![CDATA[http://localhost:3000/2/beacons/vast/acceptInvitation.gif]]></Tracking>
+                        <Tracking event="collapse"><![CDATA[http://localhost:3000/2/beacons/vast/collapse.gif]]></Tracking>
+                        <Tracking event="progress" offset="00:00:03">
+                            <![CDATA[http://localhost:3000/2/beacons/vast/progress.gif]]></Tracking>
+                    </TrackingEvents>
+                    
+                    <VideoClicks>
+                        <ClickTracking><![CDATA[http://localhost:3000/2/beacons/vast/click.gif]]></ClickTracking>
+                    </VideoClicks>
+                    
+                    <MediaFiles>
+                        <MediaFile delivery="progressive" bitrate="400" width="320" height="180" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/lo.mp4]]></MediaFile>
+                        <MediaFile delivery="progressive" bitrate="600" width="640" height="480" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/me.mp4]]></MediaFile>
+                        <MediaFile delivery="progressive" bitrate="1024" width="640" height="480" type="video/mp4"><![CDATA[http://localhost:3000/adasset/1331/229/7969/hi.mp4]]></MediaFile>
+                    </MediaFiles>
+                </Linear>
+            </Creative>
+        </Creatives>
+        <Extensions>
+        </Extensions>
+    </InLine>
+</Ad>
+</VAST><!-- 4 UA_KHARKIVSKAOBLAST_0_KHARKIV 61085 -->

--- a/sources/advertisements/VASTParserTests.swift
+++ b/sources/advertisements/VASTParserTests.swift
@@ -60,9 +60,9 @@ class VASTParserTests: XCTestCase {
     func testParseVpaidVAST() {
         let vast = getVAST(atPath: "VASTVpaid")
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail("Failed to parse VAST VPAID xml") }
-        guard case let .inline(vpaidModel) = model else { return XCTFail() }
+        guard case let .inline(inlineModel) = model else { return XCTFail() }
         let expectedURLString = "http://localhost:3000/vpaid/6/video.js"
-        XCTAssertEqual(vpaidModel.vpaidMediaFiles.first?.url.absoluteString, expectedURLString)
+        XCTAssertEqual(inlineModel.vpaidMediaFiles.first?.url.absoluteString, expectedURLString)
     }
     
     func testParseAdVerification() {
@@ -106,46 +106,56 @@ class VASTParserTests: XCTestCase {
     func testParsePixelsFromVAST() {
         let vast = getVAST(atPath: "VASTExampleCDATA")
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail("Failed to parse VAST VPAID xml") }
-        guard case let .inline(vpaidModel) = model else { return XCTFail() }
+        guard case let .inline(inlineModel) = model else { return XCTFail() }
         let url = "http://localhost:3000/6/beacons/vast/"
-        XCTAssertEqual(vpaidModel.pixels.impression.first?.absoluteString, url + "impression.gif")
-        XCTAssertEqual(vpaidModel.pixels.error.first?.absoluteString, url + "error.gif")
-        XCTAssertEqual(vpaidModel.pixels.clickTracking.first?.absoluteString, url + "click.gif")
-        XCTAssertEqual(vpaidModel.pixels.firstQuartile.first?.absoluteString, url + "firstQuartile.gif")
-        XCTAssertEqual(vpaidModel.pixels.midpoint.first?.absoluteString, url + "midpoint.gif")
-        XCTAssertEqual(vpaidModel.pixels.thirdQuartile.first?.absoluteString, url + "thirdQuartile.gif")
-        XCTAssertEqual(vpaidModel.pixels.complete.first?.absoluteString, url + "complete.gif")
-        XCTAssertEqual(vpaidModel.pixels.pause.first?.absoluteString, url + "pause.gif")
-        XCTAssertEqual(vpaidModel.pixels.resume.first?.absoluteString, url + "resume.gif")
-        XCTAssertEqual(vpaidModel.pixels.skip.first?.absoluteString, url + "skip.gif")
-        XCTAssertEqual(vpaidModel.pixels.mute.first?.absoluteString, url + "mute.gif")
-        XCTAssertEqual(vpaidModel.pixels.unmute.first?.absoluteString, url + "unmute.gif")
-        XCTAssertEqual(vpaidModel.pixels.acceptInvitation.first?.absoluteString, url + "acceptInvitation.gif")
-        XCTAssertEqual(vpaidModel.pixels.close.first?.absoluteString, url + "close.gif")
-        XCTAssertEqual(vpaidModel.pixels.collapse.first?.absoluteString, url + "collapse.gif")
-        XCTAssertEqual(vpaidModel.adProgress.first?.url.absoluteString, url + "progress.gif")
+        XCTAssertEqual(inlineModel.pixels.impression.first?.absoluteString, url + "impression.gif")
+        XCTAssertEqual(inlineModel.pixels.error.first?.absoluteString, url + "error.gif")
+        XCTAssertEqual(inlineModel.pixels.clickTracking.first?.absoluteString, url + "click.gif")
+        XCTAssertEqual(inlineModel.pixels.firstQuartile.first?.absoluteString, url + "firstQuartile.gif")
+        XCTAssertEqual(inlineModel.pixels.midpoint.first?.absoluteString, url + "midpoint.gif")
+        XCTAssertEqual(inlineModel.pixels.thirdQuartile.first?.absoluteString, url + "thirdQuartile.gif")
+        XCTAssertEqual(inlineModel.pixels.complete.first?.absoluteString, url + "complete.gif")
+        XCTAssertEqual(inlineModel.pixels.pause.first?.absoluteString, url + "pause.gif")
+        XCTAssertEqual(inlineModel.pixels.resume.first?.absoluteString, url + "resume.gif")
+        XCTAssertEqual(inlineModel.pixels.skip.first?.absoluteString, url + "skip.gif")
+        XCTAssertEqual(inlineModel.pixels.mute.first?.absoluteString, url + "mute.gif")
+        XCTAssertEqual(inlineModel.pixels.unmute.first?.absoluteString, url + "unmute.gif")
+        XCTAssertEqual(inlineModel.pixels.acceptInvitation.first?.absoluteString, url + "acceptInvitation.gif")
+        XCTAssertEqual(inlineModel.pixels.close.first?.absoluteString, url + "close.gif")
+        XCTAssertEqual(inlineModel.pixels.collapse.first?.absoluteString, url + "collapse.gif")
+        XCTAssertEqual(inlineModel.adProgress.first?.url.absoluteString, url + "progress.gif")
     }
     
     func testParseOffsetInTime() {
         let vast = getVAST(atPath: "VAST1")
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail("Failed to parse VAST VPAID xml") }
-        guard case let .inline(vpaidModel) = model else { return XCTFail() }
-        XCTAssertEqual(vpaidModel.skipOffset, .time(3663))
-        XCTAssertEqual(vpaidModel.adProgress.first?.offset, .time(60))
+        guard case let .inline(inlineModel) = model else { return XCTFail() }
+        XCTAssertEqual(inlineModel.skipOffset, .time(3663))
+        XCTAssertEqual(inlineModel.adProgress.first?.offset, .time(60))
     }
     
     func testParseOffsetInPersentage() {
         let vast = getVAST(atPath: "VASTExampleCDATA")
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail("Failed to parse VAST VPAID xml") }
-        guard case let .inline(vpaidModel) = model else { return XCTFail() }
-        XCTAssertEqual(vpaidModel.skipOffset, .percentage(32))
-        XCTAssertEqual(vpaidModel.adProgress.first?.offset, .percentage(10))
+        guard case let .inline(inlineModel) = model else { return XCTFail() }
+        XCTAssertEqual(inlineModel.skipOffset, .percentage(32))
+        XCTAssertEqual(inlineModel.adProgress.first?.offset, .percentage(10))
     }
     
     func testParseNotValidSkipOffsetInTime() {
         let vast = getVAST(atPath: "VASTVerificationInExtension")
         guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail("Failed to parse VAST VPAID xml") }
-        guard case let .inline(vpaidModel) = model else { return XCTFail() }
-        XCTAssertEqual(vpaidModel.skipOffset, nil)
+        guard case let .inline(inlineModel) = model else { return XCTFail() }
+        XCTAssertEqual(inlineModel.skipOffset, nil)
     }
+    
+    func testParseMultipleCreatives() {
+        let vast = getVAST(atPath: "VASTMultipleCreatives")
+        guard let model = VASTParser.parseFrom(string: vast) else { return XCTFail("Failed to parse VAST VPAID xml") }
+        guard case let .inline(inlineModel) = model else { return XCTFail() }
+        XCTAssertEqual(inlineModel.mp4MediaFiles.count, 3)
+        XCTAssertEqual(inlineModel.pixels.firstQuartile.count, 1)
+        XCTAssertEqual(inlineModel.skipOffset, .percentage(32))
+    }
+
 }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
We could collect all tracking and all media files from multiple creatives into a single inline model. Now if we successfully get any media file, we won't parse any other creatives.

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
