### PR TITLE
Buffering telemetry shouldn't be fired for live videos

### DIFF
--- a/sources/telemetry/Metrics.swift
+++ b/sources/telemetry/Metrics.swift
@@ -2,6 +2,7 @@
 //  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
 import Foundation
 import PlayerCore
+import CoreMedia
 
 extension Telemetry {
     struct Metrics {
@@ -191,7 +192,6 @@ extension Telemetry.Metrics {
                 self.context = context
                 self.send = send
             }
-            
             func process(uniqueKey: UUID?,
                          processingTime: BufferingStatus,
                          telemetryType: String) {
@@ -226,7 +226,8 @@ extension Telemetry.Metrics {
                         processingStatus: state.vrmProcessingTime.status)
             
             content.process(playbackSession: state.playbackSession.id,
-                            processingStatus: state.contentBufferingTime.status)
+                            processingStatus: state.contentBufferingTime.status,
+                            duration: state.duration.content)
         }
     }
 }
@@ -271,7 +272,11 @@ extension Telemetry.Metrics.Buffering {
             content = Reporter(context: context, send: send)
         }
         
-        func process(playbackSession: UUID?, processingStatus: BufferingStatus) {
+        func process(playbackSession: UUID?,
+                     processingStatus: BufferingStatus,
+                     duration: CMTime?) {
+            guard let duration = duration,
+                CMTIME_IS_INDEFINITE(duration) == false else { return }
             content.process(uniqueKey: playbackSession,
                         processingTime: processingStatus,
                         telemetryType: "VIDEO_BUFFERING_TIME")

--- a/sources/telemetry/TelemetryMetricsTest.swift
+++ b/sources/telemetry/TelemetryMetricsTest.swift
@@ -2,6 +2,7 @@
 //  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
 
 import XCTest
+import CoreMedia
 @testable import PlayerCore
 @testable import VerizonVideoPartnerSDK
 
@@ -312,17 +313,40 @@ class TelemetryMetricsTest: XCTestCase {
     func testContentBufferingTime() {
         let startAt = Date(timeIntervalSince1970: 0)
         let finishAt = Date(timeIntervalSince1970: 2.5)
-        
+        let duration = CMTime(seconds: 30, preferredTimescale: 600)
         recorder.record {
             let sessionId = UUID()
-            contentBuffering.process(playbackSession: sessionId, processingStatus: .inProgress(startAt: startAt))
-            contentBuffering.process(playbackSession: sessionId, processingStatus: .finished(startAt: startAt, finishAt: finishAt))
-            contentBuffering.process(playbackSession: sessionId, processingStatus: .finished(startAt: startAt, finishAt: finishAt))
+            contentBuffering.process(playbackSession: sessionId,
+                                     processingStatus: .inProgress(startAt: startAt),
+                                     duration: duration)
+            contentBuffering.process(playbackSession: sessionId,
+                                     processingStatus: .finished(startAt: startAt, finishAt: finishAt),
+                                     duration: duration)
+            contentBuffering.process(playbackSession: sessionId,
+                                     processingStatus: .finished(startAt: startAt, finishAt: finishAt),
+                                     duration: duration)
         }
         
         recorder.verify {
             contentBuffering.content.send(json(for: "VIDEO_BUFFERING_TIME",
                                               and: ["time": 2500]))
+        }
+    }
+    func testContentBufferingTimeWithLiveVideo() {
+        let startAt = Date(timeIntervalSince1970: 0)
+        let finishAt = Date(timeIntervalSince1970: 2.5)
+        let duration = CMTime.indefinite
+        recorder.record {
+            let sessionId = UUID()
+            contentBuffering.process(playbackSession: sessionId,
+                                     processingStatus: .inProgress(startAt: startAt),
+                                     duration: duration)
+            contentBuffering.process(playbackSession: sessionId,
+                                     processingStatus: .finished(startAt: startAt, finishAt: finishAt),
+                                     duration: duration)
+        }
+        
+        recorder.verify {
         }
     }
     


### PR DESCRIPTION
@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
