### PR TITLE
Fix for om sdk init

### DIFF
--- a/sources/metrics/open measurement/OpenMeasurementContext.swift
+++ b/sources/metrics/open measurement/OpenMeasurementContext.swift
@@ -16,13 +16,17 @@ enum OpenMeasurement {
         let adEvents: PlayerCore.OpenMeasurement.AdEvents
         let videoEvents: PlayerCore.OpenMeasurement.VideoEvents
     }
-    enum Errors: Swift.Error {
+    enum Errors: CustomNSError {
         case failedToCreateOMIDPartner
         case failedToCreateVerificationScriptResource
         case failedToActivateSDK
         case scriptNotAvailable
         case failedToGetAdView
         case sdkVersionIsNotCompatible
+        
+        var errorUserInfo: [String : Any] {
+            return [NSLocalizedDescriptionKey : "\(self)"]
+        }
     }
     
     static func createOpenMeasurementContext(input: Input) throws -> Output {
@@ -45,19 +49,19 @@ enum OpenMeasurement {
                     return OMIDVerizonmediaVerificationScriptResource(url: $0.javaScriptResource)
                 }
                 return OMIDVerizonmediaVerificationScriptResource(url: $0.javaScriptResource,
-                                                       vendorKey: vendorKey,
-                                                       parameters: parameters.absoluteString)
+                                                                  vendorKey: vendorKey,
+                                                                  parameters: parameters.absoluteString)
             }
         }()
         
         let context = try OMIDVerizonmediaAdSessionContext(partner: partner,
-                                                    script: input.jsServiceScript,
-                                                    resources: verificationResources,
-                                                    customReferenceIdentifier: nil)
+                                                           script: input.jsServiceScript,
+                                                           resources: verificationResources,
+                                                           customReferenceIdentifier: nil)
         
         let configuration = try OMIDVerizonmediaAdSessionConfiguration(impressionOwner: .nativeOwner,
-                                                                videoEventsOwner: .nativeOwner,
-                                                                isolateVerificationScripts: false)
+                                                                       videoEventsOwner: .nativeOwner,
+                                                                       isolateVerificationScripts: false)
         
         let adSession = try OMIDVerizonmediaAdSession(configuration: configuration, adSessionContext: context)
         

--- a/sources/metrics/open measurement/OpenMeasurementControllerTests.swift
+++ b/sources/metrics/open measurement/OpenMeasurementControllerTests.swift
@@ -76,7 +76,7 @@ class OpenMeasurementComponentTestCase: XCTestCase {
     func testNoScriptAvailable() {
         recorder.record {
             controller.serviceScript = nil
-            controller.process(with: .loading(adVerifications))
+            controller.process(with: .loading)
         }
         
         recorder.verify {
@@ -87,7 +87,8 @@ class OpenMeasurementComponentTestCase: XCTestCase {
     }
     func testActivatedSuccessfully() {
         recorder.record {
-            controller.process(with: .loading(adVerifications))
+            controller.process(with: .readyForLoad(adVerifications))
+            controller.process(with: .loading)
         }
         
         recorder.verify {
@@ -99,7 +100,9 @@ class OpenMeasurementComponentTestCase: XCTestCase {
         XCTAssertNotNil(adSession.mainAdView)
     }
     func testActivatedState() {
-        controller.process(with: .loading(adVerifications))
+        controller.process(with: .readyForLoad(adVerifications))
+        controller.process(with: .loading)
+        
         recorder.record {
             controller.process(with: .active(adEvents, videoEvents))
         }
@@ -109,7 +112,8 @@ class OpenMeasurementComponentTestCase: XCTestCase {
         XCTAssertFalse(adSession.isFinished)
     }
     func testShouldNotBeFinished() {
-        controller.process(with: .loading(adVerifications))
+        controller.process(with: .readyForLoad(adVerifications))
+        controller.process(with: .loading)
         
         recorder.record {
             controller.process(with: .finished(adEvents,videoEvents))
@@ -122,7 +126,8 @@ class OpenMeasurementComponentTestCase: XCTestCase {
         XCTAssertFalse(adSession.isFinished)
     }
     func testShouldBeFinished() {
-        controller.process(with: .loading(adVerifications))
+        controller.process(with: .readyForLoad(adVerifications))
+        controller.process(with: .loading)
         controller.process(with: .finished(adEvents,videoEvents))
         controller.process(with: .inactive)
         XCTAssertTrue(adSession.isStarted)
@@ -140,7 +145,8 @@ class OpenMeasurementComponentTestCase: XCTestCase {
         controller.serviceScript = "{}"
         
         recorder.record {
-            controller.process(with: .loading(adVerifications))
+            controller.process(with: .readyForLoad(adVerifications))
+            controller.process(with: .loading)
         }
         
         recorder.verify {
@@ -157,12 +163,13 @@ class OpenMeasurementComponentTestCase: XCTestCase {
         controller.serviceScript = "{}"
         
         recorder.record {
-            controller.process(with: .loading(adVerifications))
+            controller.process(with: .readyForLoad(adVerifications))
+            controller.process(with: .loading)
         }
         
         recorder.verify {
-            dispatcher(PlayerCore.failedOMConfiguration(with: OMErrors.failedToGetAdView))
         }
+        
         XCTAssertFalse(adSession.isStarted)
         XCTAssertFalse(adSession.isFinished)
     }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Update OM SDK Controller for waiting ad view if it doesn't exist. 
Also remove sending telemetry for this case.

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.