### PR TITLE
Added Tracking Properties New Connector for failover detector

### DIFF
--- a/VerizonVideoPartnerSDK.xcodeproj/project.pbxproj
+++ b/VerizonVideoPartnerSDK.xcodeproj/project.pbxproj
@@ -15,6 +15,12 @@
 		061CFFFF211C7272002B5BE9 /* MuteDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061CFFFD211C7272002B5BE9 /* MuteDetector.swift */; };
 		061EB355222573C700DF149C /* VASTMultipleCreatives.xml in Resources */ = {isa = PBXBuildFile; fileRef = 061EB3522225731F00DF149C /* VASTMultipleCreatives.xml */; };
 		062E9B3E20F5097C00AF1D54 /* PlayerViewController_Clickthrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062E9B3D20F5097C00AF1D54 /* PlayerViewController_Clickthrough.swift */; };
+		0633BA11223BA512004A8474 /* TrackingPixelsProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0633BA10223BA512004A8474 /* TrackingPixelsProperties.swift */; };
+		0633BA12223BA512004A8474 /* TrackingPixelsProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0633BA10223BA512004A8474 /* TrackingPixelsProperties.swift */; };
+		0633BA4C223BD941004A8474 /* TrackingPixelsProperties_init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0633BA4B223BD941004A8474 /* TrackingPixelsProperties_init.swift */; };
+		0633BA4D223BD941004A8474 /* TrackingPixelsProperties_init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0633BA4B223BD941004A8474 /* TrackingPixelsProperties_init.swift */; };
+		0633BA82223FA7C5004A8474 /* TrackingPixelsPropsConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0633BA81223FA7C5004A8474 /* TrackingPixelsPropsConnector.swift */; };
+		0633BA87223FBF04004A8474 /* TrackingPixelsPropsConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0633BA81223FA7C5004A8474 /* TrackingPixelsPropsConnector.swift */; };
 		063988A72100C95000FE8475 /* VPAIDMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063988A62100C95000FE8475 /* VPAIDMessageHandler.swift */; };
 		063C8354221C568D0052C1DC /* AdEngineResponseDetectorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26043F9220885B60034FC48 /* AdEngineResponseDetectorSpec.swift */; };
 		063C8374221D9AD00052C1DC /* AdSkipDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EC86CA221467C300CB4A8E /* AdSkipDetector.swift */; };
@@ -460,6 +466,9 @@
 		061CFFFD211C7272002B5BE9 /* MuteDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuteDetector.swift; sourceTree = "<group>"; };
 		061EB3522225731F00DF149C /* VASTMultipleCreatives.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = VASTMultipleCreatives.xml; sourceTree = "<group>"; };
 		062E9B3D20F5097C00AF1D54 /* PlayerViewController_Clickthrough.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlayerViewController_Clickthrough.swift; path = "sources/custom controls/PlayerViewController_Clickthrough.swift"; sourceTree = "<group>"; };
+		0633BA10223BA512004A8474 /* TrackingPixelsProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingPixelsProperties.swift; sourceTree = "<group>"; };
+		0633BA4B223BD941004A8474 /* TrackingPixelsProperties_init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingPixelsProperties_init.swift; sourceTree = "<group>"; };
+		0633BA81223FA7C5004A8474 /* TrackingPixelsPropsConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingPixelsPropsConnector.swift; sourceTree = "<group>"; };
 		063988A62100C95000FE8475 /* VPAIDMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPAIDMessageHandler.swift; sourceTree = "<group>"; };
 		06419E1720EF7433007FE2F0 /* WebviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebviewViewController.swift; sourceTree = "<group>"; };
 		06419E2020EF7950007FE2F0 /* VPAIDProps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPAIDProps.swift; sourceTree = "<group>"; };
@@ -1241,10 +1250,13 @@
 			isa = PBXGroup;
 			children = (
 				DE4C51BE1C80839100BFFB0B /* generator */,
-				DE4C51571C80731B00BFFB0B /* TrackingPixelsReporter.swift */,
 				DE07F0501EF9956B00C8E9F2 /* ReporterTracer.swift */,
 				DE4C51E01C80D43200BFFB0B /* TrackingPixelsConnector.swift */,
+				0633BA81223FA7C5004A8474 /* TrackingPixelsPropsConnector.swift */,
 				50D629D220237BA5000B2F8F /* TrackingPixelsConnector_Ad.swift */,
+				0633BA10223BA512004A8474 /* TrackingPixelsProperties.swift */,
+				0633BA4B223BD941004A8474 /* TrackingPixelsProperties_init.swift */,
+				DE4C51571C80731B00BFFB0B /* TrackingPixelsReporter.swift */,
 			);
 			path = "tracking pixels";
 			sourceTree = "<group>";
@@ -1793,6 +1805,7 @@
 				5034AD2B207E69CA00B5CAA1 /* VideoSelector.swift in Sources */,
 				501AB1D9202892DA00BAFA9C /* AdClickDetector.swift in Sources */,
 				E22B6ADD21F0A9C200D480A0 /* VRMProcessingController.swift in Sources */,
+				0633BA87223FBF04004A8474 /* TrackingPixelsPropsConnector.swift in Sources */,
 				50A11DAA1D59D7E000F4A068 /* Disposable.swift in Sources */,
 				50A11DAB1D59D7E000F4A068 /* Network.swift in Sources */,
 				E22B6ADC21F0A95700D480A0 /* VVPSDK_Version.swift in Sources */,
@@ -1813,6 +1826,7 @@
 				06BF53D4209B59E300B98A6D /* UserActionsDetector.swift in Sources */,
 				50A11DBC1D59D7E000F4A068 /* VideoTimeDetector.swift in Sources */,
 				FEEB8E5A1F4C92F4003507BE /* ErrorDetector.swift in Sources */,
+				0633BA4D223BD941004A8474 /* TrackingPixelsProperties_init.swift in Sources */,
 				50A11DBD1D59D7E000F4A068 /* VRMProvider.swift in Sources */,
 				E2FE09562200AC14005E91C0 /* MaxAdSearchTimeController.swift in Sources */,
 				501AB1DF2028934A00BAFA9C /* AdErrorDetector.swift in Sources */,
@@ -1843,6 +1857,7 @@
 				069DC3E820EA9BA600D70B28 /* VPAIDEvents.swift in Sources */,
 				50A11DCC1D59D7E000F4A068 /* MetricsSender.swift in Sources */,
 				E2E575962211E0D40068C394 /* VRMMidrollProcessorController.swift in Sources */,
+				0633BA12223BA512004A8474 /* TrackingPixelsProperties.swift in Sources */,
 				DEB1123D1E30F56C007E65BD /* ConfigurationParser.swift in Sources */,
 				5070535A1DAE9700003C023A /* Memoise.swift in Sources */,
 				50A11DCE1D59D7E000F4A068 /* ContextStartedDetector.swift in Sources */,
@@ -1941,6 +1956,7 @@
 				06FDBCCD223941F000462527 /* FailoverDetector.swift in Sources */,
 				DE06F78C1E7AB647006B5DD3 /* VideoProviderResponse.swift in Sources */,
 				50CFB5281FB61EA20017328C /* PlayerProperties_Init.swift in Sources */,
+				0633BA4C223BD941004A8474 /* TrackingPixelsProperties_init.swift in Sources */,
 				DE4C51C01C808D8000BFFB0B /* DecileDetector.swift in Sources */,
 				06EC86EC2214841D00CB4A8E /* AdVASTProgressDetector.swift in Sources */,
 				DE4C51C11C808DD400BFFB0B /* QuartileDetector.swift in Sources */,
@@ -1951,6 +1967,7 @@
 				06419E2120EF7950007FE2F0 /* VPAIDProps.swift in Sources */,
 				DE4C51C51C8094FB00BFFB0B /* TrackingPixelsReporter.swift in Sources */,
 				501AB1E42029C69C00BAFA9C /* AdPlaybackCycleDetector.swift in Sources */,
+				0633BA11223BA512004A8474 /* TrackingPixelsProperties.swift in Sources */,
 				DE4C51C61C8094FE00BFFB0B /* MetricsSender.swift in Sources */,
 				067209BC21B6BD9A0086CDBE /* OpenMeasurementServiceScript.swift in Sources */,
 				06419E1A20EF7433007FE2F0 /* WebviewViewController.swift in Sources */,
@@ -1960,6 +1977,7 @@
 				06EC86B72214398E00CB4A8E /* VASTParser_Offset.swift in Sources */,
 				DEB1123C1E30F56C007E65BD /* ConfigurationParser.swift in Sources */,
 				501C8BD71D1C0B8200C52AB3 /* ContextStartedDetector.swift in Sources */,
+				0633BA82223FA7C5004A8474 /* TrackingPixelsPropsConnector.swift in Sources */,
 				06B13EF22090AB13009A6645 /* AdViewTimeDetector.swift in Sources */,
 				50A5A5E61E79726E00C15E12 /* 3secPlaybackDetector.swift in Sources */,
 				069DC48420EA9EC400D70B28 /* VPAIDEvents.swift in Sources */,

--- a/sources/VVPSDK.swift
+++ b/sources/VVPSDK.swift
@@ -301,6 +301,9 @@ public struct VVPSDK {
             _ = player.addObserver(connector.process)
             _ = player.store.addObserver(with: playerModel, mode: .everyUpdate, connector.process)
             
+            let propsConnector = TrackingPixels.PropsConnector(reporter: reporter)
+            _ = player.addTrackingObserver(propsConnector.process)
+            
         case (.javascript(let context), .javascript(let javascript)):
             func send(url: URL) {
                 ephemeralSession.dataTask(with: url).resume()

--- a/sources/metrics/detectors/failover/FailoverDetector.swift
+++ b/sources/metrics/detectors/failover/FailoverDetector.swift
@@ -6,34 +6,21 @@ import PlayerCore
 extension Detectors {
     final class Failover {
         
-        private enum AdResult {
-            case none
-            case failover
-        }
+        private var adSessionIds = Set<UUID>()
         
-        private var adSessionIDs = Set<UUID>()
-        
-        func process(vrmResponse: VRMResponse?,
-                     currentGroup: VRMCore.Group?,
-                     groupQueue: [VRMCore.Group],
-                     adSessionID: UUID?) -> Bool {
-            guard let vrmResponse = vrmResponse,
-                let adSessionID = adSessionID,
-                adSessionIDs.contains(adSessionID) == false else {
+        func process(isVRMResponseGroupsEmpty: Bool,
+                     isCurrentVRMGroupEmpty: Bool,
+                     isVRMGroupsQueueEmpty: Bool,
+                     adSessionId: UUID?) -> Bool {
+            guard let adSessionId = adSessionId,
+                adSessionIds.contains(adSessionId) == false else {
                     return false
             }
-            func finishProcessing(with result: AdResult) -> Bool {
-                self.adSessionIDs.insert(adSessionID)
-                return result == .failover
-            }
-            guard vrmResponse.groups.isEmpty == false else {
-                return finishProcessing(with: .none)
-            }
-            guard currentGroup == nil,
-                groupQueue.isEmpty else {
-                    return false
-            }
-            return finishProcessing(with: .failover)
+            guard isVRMResponseGroupsEmpty == false,
+                isCurrentVRMGroupEmpty,
+                isVRMGroupsQueueEmpty else { return false }
+            self.adSessionIds.insert(adSessionId)
+            return true
         }
     }
 }

--- a/sources/metrics/detectors/failover/FailoverDetectorTests.swift
+++ b/sources/metrics/detectors/failover/FailoverDetectorTests.swift
@@ -7,96 +7,56 @@ import XCTest
 
 class FailoverDetectorsTests: XCTestCase {
     
-    let adSessionID = UUID()
+    let adRequestId = UUID()
     var detector: Detectors.Failover!
-    var group: VRMCore.Group!
-    var response: VRMResponse!
-    let item = VRMCore.Item(source: VRMCore.Item.Source.vast(""),
-                            metaInfo: VRMCore.Item.MetaInfo.init(engineType: "",
-                                                                 ruleId: "",
-                                                                 ruleCompanyId: "",
-                                                                 vendor: "",
-                                                                 name: "",
-                                                                 cpm: ""))
     
     override func setUp() {
         super.setUp()
         detector = Detectors.Failover()
-        group = VRMCore.Group(items: [])
-        response = VRMResponse(transactionId: "", slot: "", groups: [group])
     }
     
-    
-    func testResponseWithoutVRMResponse() {
-        let result = detector.process(vrmResponse: nil,
-                                       currentGroup: group,
-                                       groupQueue: [],
-                                       adSessionID: adSessionID)
-        XCTAssertFalse(result)
-    }
     func testResponseAndNonEmptyGroupQueue() {
-        let result = detector.process(vrmResponse: response,
-                                      currentGroup: group,
-                                      groupQueue: [group],
-                                      adSessionID: adSessionID)
+        let result = detector.process(isVRMResponseGroupsEmpty: false,
+                                      isCurrentVRMGroupEmpty: false,
+                                      isVRMGroupsQueueEmpty: false,
+                                      adSessionId: adRequestId)
         XCTAssertFalse(result)
     }
     func testResponseWithEmptyGroupQueue() {
-        let result = detector.process(vrmResponse: response,
-                                      currentGroup: group,
-                                      groupQueue: [],
-                                      adSessionID: adSessionID)
+        let result = detector.process(isVRMResponseGroupsEmpty: false,
+                                      isCurrentVRMGroupEmpty: false,
+                                      isVRMGroupsQueueEmpty: true,
+                                      adSessionId: adRequestId)
         XCTAssertFalse(result)
     }
     
     func testFailoverCase() {
-        var result = detector.process(vrmResponse: response,
-                                      currentGroup: group,
-                                      groupQueue: [group],
-                                      adSessionID: adSessionID)
-        result = detector.process(vrmResponse: response,
-                                  currentGroup: group,
-                                  groupQueue: [],
-                                  adSessionID: adSessionID)
-        result = detector.process(vrmResponse: response,
-                                  currentGroup: nil,
-                                  groupQueue: [],
-                                  adSessionID: adSessionID)
+        let result = detector.process(isVRMResponseGroupsEmpty: false,
+                                  isCurrentVRMGroupEmpty: true,
+                                  isVRMGroupsQueueEmpty: true,
+                                  adSessionId: adRequestId)
         XCTAssertTrue(result)
     }
     
     func testResponseWithNoAds() {
-        let emptyResponse = VRMResponse(transactionId: "", slot: "", groups: [])
-        var result = detector.process(vrmResponse: nil,
-                                      currentGroup: nil,
-                                      groupQueue: [],
-                                      adSessionID: adSessionID)
-        result = detector.process(vrmResponse: emptyResponse,
-                                  currentGroup: nil,
-                                  groupQueue: [],
-                                  adSessionID: adSessionID)
+        let result = detector.process(isVRMResponseGroupsEmpty: true,
+                                      isCurrentVRMGroupEmpty: true,
+                                      isVRMGroupsQueueEmpty: true,
+                                      adSessionId: adRequestId)
         XCTAssertFalse(result)
     }
     func testResponseWithMultipleAdSessions() {
-        var result = detector.process(vrmResponse: response,
-                                      currentGroup: group,
-                                      groupQueue: [group],
-                                      adSessionID: adSessionID)
-        result = detector.process(vrmResponse: response,
-                                  currentGroup: nil,
-                                  groupQueue: [],
-                                  adSessionID: adSessionID)
+        var result = detector.process(isVRMResponseGroupsEmpty: false,
+                                      isCurrentVRMGroupEmpty: true,
+                                      isVRMGroupsQueueEmpty: true,
+                                      adSessionId: adRequestId)
         XCTAssertTrue(result)
         
-        let newSessionID = UUID()
-        result = detector.process(vrmResponse: response,
-                                      currentGroup: group,
-                                      groupQueue: [group],
-                                      adSessionID: newSessionID)
-        result = detector.process(vrmResponse: response,
-                                  currentGroup: nil,
-                                  groupQueue: [],
-                                  adSessionID: newSessionID)
+        let newRequestId = UUID()
+        result = detector.process(isVRMResponseGroupsEmpty: false,
+                                  isCurrentVRMGroupEmpty: true,
+                                  isVRMGroupsQueueEmpty: true,
+                                  adSessionId: newRequestId)
         XCTAssertTrue(result)
     }
 }

--- a/sources/metrics/tracking pixels/TrackingPixelsConnector_Ad.swift
+++ b/sources/metrics/tracking pixels/TrackingPixelsConnector_Ad.swift
@@ -98,25 +98,7 @@ extension TrackingPixels.Connector {
             func pixels() -> PlayerCore.AdPixels {
                 if let pixels = state.vrmFinalResult.successResult?.inlineVAST.pixels ??
                                 state.vrmFinalResult.failedResult?.inlineVAST.pixels {
-                    return .init(impression: pixels.impression,
-                                 error: pixels.error,
-                                 clickTracking: pixels.clickTracking,
-                                 creativeView: pixels.creativeView,
-                                 start: pixels.start,
-                                 firstQuartile: pixels.firstQuartile,
-                                 midpoint: pixels.midpoint,
-                                 thirdQuartile: pixels.thirdQuartile,
-                                 complete: pixels.complete,
-                                 pause: pixels.pause,
-                                 resume: pixels.resume,
-                                 skip: pixels.skip,
-                                 mute: pixels.mute,
-                                 unmute: pixels.unmute,
-                                 acceptInvitation: pixels.acceptInvitation,
-                                 acceptInvitationLinear: pixels.acceptInvitationLinear,
-                                 close: pixels.close,
-                                 closeLinear: pixels.closeLinear,
-                                 collapse: pixels.collapse)
+                    return pixels
                 } else {
                     fatalError("No pixels which are required to fire!")
                 }
@@ -211,16 +193,6 @@ extension TrackingPixels.Connector {
             let urls = adProgressDetector.process(currentTime: state.currentTime.ad.seconds,
                                                   progressPixelsArray: state.adProgress.pixels)
             reporter.sendBeacon(urls: urls)
-        }
-        /*Ad Failover Detector*/ do {
-            if adFailoverDetector.process(vrmResponse: state.vrmResponse,
-                                          currentGroup: state.vrmCurrentGroup.currentGroup,
-                                          groupQueue: state.vrmGroupsQueue.groupsQueue,
-                                          adSessionID: sessionID) {
-                report { payload in
-                    engineFlow(stage: .failover, payload: payload)
-                }
-            }
         }
         switch state.selectedAdCreative {
         case .vpaid:

--- a/sources/metrics/tracking pixels/TrackingPixelsProperties.swift
+++ b/sources/metrics/tracking pixels/TrackingPixelsProperties.swift
@@ -1,0 +1,31 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import Foundation
+import PlayerCore
+
+enum TrackingPixels {
+    struct Properties {
+        let metaInfo: MetaInfo
+        let session: AdSession
+        
+        struct MetaInfo {
+            let adType: Ad.Metrics.PlayType
+            let adVASTId: String?
+            let adMetricsInfo: Ad.Metrics.Info?
+            let slot: String?
+            let adRequestId: UUID?
+            let transactionId: String?
+        }
+        struct AdSession {
+            let playerDimensions: CGSize?
+            let playbackSessionId: String
+            let videoIndex: Int
+            let isCurrentVRMGroupEmpty: Bool
+            let isVRMGroupsQueueEmpty: Bool
+            let isVRMResponseGroupsEmpty: Bool
+            let isAutoplayEnabled: Bool
+        }
+    }
+}
+

--- a/sources/metrics/tracking pixels/TrackingPixelsProperties_init.swift
+++ b/sources/metrics/tracking pixels/TrackingPixelsProperties_init.swift
@@ -1,0 +1,48 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import Foundation
+import PlayerCore
+
+extension TrackingPixels.Properties {
+    
+    init(state: State, model: PlayerCore.Model) {
+        metaInfo = TrackingPixels.Properties.MetaInfo(state: state, model: model)
+        session = TrackingPixels.Properties.AdSession(state: state, model: model)
+    }
+}
+extension TrackingPixels.Properties.MetaInfo {
+    init(state: State, model: PlayerCore.Model) {
+        adType = perform {
+            switch state.ad.currentType {
+            case .preroll: return .preroll
+            case .midroll: return .midroll
+            }
+        }
+        adVASTId = perform {
+            guard let inline = state.vrmFinalResult.successResult ?? state.vrmFinalResult.failedResult,
+                state.vrmResponse != nil else { return nil }
+            return inline.inlineVAST.id
+        }
+        adMetricsInfo = perform {
+            guard let inline = state.vrmFinalResult.successResult ?? state.vrmFinalResult.failedResult,
+                state.vrmResponse != nil else { return nil }
+            return Ad.Metrics.Info(metaInfo: inline.item.metaInfo)
+        }
+        slot = state.vrmResponse?.slot
+        adRequestId = state.vrmRequestStatus.request?.id
+        transactionId = state.vrmResponse?.transactionId
+    }
+}
+
+extension TrackingPixels.Properties.AdSession {
+    init(state: State, model: PlayerCore.Model) {
+        playerDimensions = state.viewport.dimensions
+        playbackSessionId = state.playbackSession.id.uuidString
+        videoIndex = state.playlist.currentIndex
+        isCurrentVRMGroupEmpty = state.vrmCurrentGroup.currentGroup == nil
+        isVRMGroupsQueueEmpty = state.vrmGroupsQueue.groupsQueue.isEmpty
+        isVRMResponseGroupsEmpty = state.vrmResponse?.groups.isEmpty == true
+        isAutoplayEnabled = model.isAutoplayEnabled
+    }
+}

--- a/sources/metrics/tracking pixels/TrackingPixelsPropsConnector.swift
+++ b/sources/metrics/tracking pixels/TrackingPixelsPropsConnector.swift
@@ -1,0 +1,34 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+extension TrackingPixels {
+    struct PropsConnector {
+        let failoverDetector = Detectors.Failover()
+        
+        let reporter: Reporter
+        
+        init(reporter: Reporter) { self.reporter = reporter }
+        
+        func process(_ props: TrackingPixels.Properties) {
+            func engineFlow(stage: Ad.Metrics.ExecutionStage) {
+                guard let adMetricsInfo = props.metaInfo.adMetricsInfo else { return }
+                reporter.adEngineFlow(videoIndex: props.session.videoIndex,
+                                      info: adMetricsInfo,
+                                      type: props.metaInfo.adType,
+                                      stage: stage,
+                                      width: props.session.playerDimensions?.width,
+                                      height: props.session.playerDimensions?.height,
+                                      autoplay: props.session.isAutoplayEnabled,
+                                      transactionId: props.metaInfo.transactionId,
+                                      adId: props.metaInfo.adVASTId,
+                                      videoViewUID: props.session.playbackSessionId)
+            }
+            
+            guard failoverDetector.process(isVRMResponseGroupsEmpty: props.session.isVRMResponseGroupsEmpty,
+                                           isCurrentVRMGroupEmpty: props.session.isCurrentVRMGroupEmpty,
+                                           isVRMGroupsQueueEmpty: props.session.isVRMGroupsQueueEmpty,
+                                           adSessionId: props.metaInfo.adRequestId) else { return }
+            engineFlow(stage: .failover)
+        }
+    }
+}

--- a/sources/metrics/tracking pixels/TrackingPixelsReporter.swift
+++ b/sources/metrics/tracking pixels/TrackingPixelsReporter.swift
@@ -2,8 +2,6 @@
 //  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
 import Foundation
 
-enum TrackingPixels {}
-
 extension TrackingPixels {
     final class Reporter {
         enum Item {

--- a/sources/player/Player.swift
+++ b/sources/player/Player.swift
@@ -49,6 +49,18 @@ public final class Player {
         }
     }
     
+    
+    typealias TrackingPropsObserver = (TrackingPixels.Properties) -> ()
+    typealias TrackingPropsObserverDispose = () -> ()
+    
+    func addTrackingObserver(on queue: DispatchQueue = .main,
+                             mode: ObservationMode = .throttleUpdates,
+                             _ observer: @escaping TrackingPropsObserver) -> TrackingPropsObserverDispose {
+        return store.addObserver(with: model, on: queue, mode: mode) { state, model in
+            observer(TrackingPixels.Properties(state: state, model: model))
+        }
+    }
+    
     func dispatch(action: PlayerCore.Action, type: DispatchType = .async) {
         store.dispatch(action: action, type: type)
     }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Added `TrackingPixels.Properties` that for now describe all props that are necessary to fire ad engine flow tracker.
- Added `NewConnector` that will work along with the old one until we move everything on a new one. 
- Moved failover detector to the new connector.

@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
