### PR TITLE
Playback stuck after receiving malformed VRM response

### DIFF
--- a/sources/advertisements/VRMProvider.swift
+++ b/sources/advertisements/VRMProvider.swift
@@ -30,7 +30,16 @@ struct VRMProvider {
             transactionId: parseTransactionId(from: json),
             slot: try parseSlot(from: json),
             cpm: try parseCpm(from: json),
-            items: try parseGroups(from: json).map { try $0.map(parseItem) })
+            items: try parseGroups(from: json).compactMap {
+                $0.compactMap {
+                    do {
+                        return try parseItem(json: $0)
+                    } catch {
+                        return nil
+                    }
+                }
+            }
+        )
     }
     
     static func parseItem(json: JSON) throws -> Item {


### PR DESCRIPTION
Fix players getting stuck trying to play prerolls after receiving malformed VRM responses by filtering out ad engine groups with invalid vast urls.