### PR TITLE
update macos image to latest to test sourcery+homebrew build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 matrix:
   include:
   - os: osx
-    osx_image: xcode10.3
+    osx_image: xcode11
     before_script:
     - ". ./fastlane/travis-scripts/pre-xcode10.sh"
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 matrix:
   include:
   - os: osx
-    osx_image: xcode11
+    osx_image: xcode11.6
     before_script:
     - ". ./fastlane/travis-scripts/pre-xcode10.sh"
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 matrix:
   include:
   - os: osx
-    osx_image: xcode12.2
+    osx_image: xcode10.3
     before_script:
     - ". ./fastlane/travis-scripts/pre-xcode10.sh"
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 matrix:
   include:
   - os: osx
-    osx_image: xcode10.2
+    osx_image: xcode12.2
     before_script:
     - ". ./fastlane/travis-scripts/pre-xcode10.sh"
     script:

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" == 2.0.0
-github "Quick/Nimble" == 8.0.1
+github "Quick/Quick" == 3.0.0
+github "Quick/Nimble" == 9.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v8.0.1"
-github "Quick/Quick" "v2.0.0"
+github "Quick/Nimble" "v9.0.0"
+github "Quick/Quick" "v3.0.0"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ actions_path 'actions/json/'
 actions_path 'actions/utils/'
 
 before_all do |_lane, _options|
-  xcversion(version: '~> 11.0')
+  xcversion(version: '~> 11.6')
 end
 
 lane :clean do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ actions_path 'actions/json/'
 actions_path 'actions/utils/'
 
 before_all do |_lane, _options|
-  xcversion(version: '~> 10.2')
+  xcversion(version: '~> 11.0')
 end
 
 lane :clean do

--- a/sources/advertisements/VRMProviderTests.swift
+++ b/sources/advertisements/VRMProviderTests.swift
@@ -65,7 +65,6 @@ class VRMProviderTests: QuickSpec {
                 expect {
                     let result = try VRMProvider.parseCpm(from: [:])
                     expect(result).to(beNil())
-                    return result
                 }.toNot(throwError())
             }
             
@@ -74,7 +73,6 @@ class VRMProviderTests: QuickSpec {
                     let result = try VRMProvider.parseCpm(from: ["cpm" : "NTA="])
                     expect(result).toNot(beNil())
                     expect(result) == "50"
-                    return result
                 }.toNot(throwError())
             }
             
@@ -82,7 +80,6 @@ class VRMProviderTests: QuickSpec {
                 expect {
                     let result = try VRMProvider.parseCpm(from: ["cpm" : "cpm"])
                     expect(result).to(beNil())
-                    return result
                     }.toNot(throwError())
             }
         }


### PR DESCRIPTION
Trying to resolve the following error:
```
sourcery: A full installation of Xcode.app 10.2 is required to compile this software. Installing just the Command Line Tools is not sufficient.
Xcode 10.2 cannot be installed on macOS 10.13.
You must upgrade your version of macOS.
Error: An unsatisfied requirement failed this build.
The command "brew install sourcery" failed and exited with 1 during
```
 from: https://travis-ci.com/github/VerizonAdPlatforms/VerizonVideoPartnerSDK-iOS/builds/197406253

I also found [this post](https://travis-ci.community/t/xcode-10-2-requires-macos-10-14-4-to-build-many-formulae/2985/3) from former developers of this project.

## Changes
```diff
diff --git a/.travis.yml b/.travis.yml
index 6c73615..5a107cb 100644
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 matrix:
   include:
   - os: osx
-    osx_image: xcode10.2
+    osx_image: xcode10.3
     before_script:
     - ". ./fastlane/travis-scripts/pre-xcode10.sh"
     script:
```


@VerizonAdPlatforms/video-partner-sdk-developers: Please review.
